### PR TITLE
Add 6MD Changelog Source and Retarget Changelog Automation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-  CHANGELOG_DIR: Resources/Changelog/Monolith.yml # Mono
+  CHANGELOG_DIR: Resources/Changelog/6MD.yml # 6MD
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,11 +46,11 @@ jobs:
         PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
         GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
 
-    - name: Publish changelog (Discord)
-      run: Tools/actions_changelogs_since_last_run.py
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DISCORD_WEBHOOK_URL: ${{ secrets.CHANGELOG_DISCORD_WEBHOOK }}
+    #- name: Publish changelog (Discord)
+    #  run: Tools/actions_changelogs_since_last_run.py
+    #  env:
+    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #    DISCORD_WEBHOOK_URL: ${{ secrets.CHANGELOG_DISCORD_WEBHOOK }}
 
     #- name: Publish changelog (RSS)
     #  run: Tools/actions_changelog_rss.py

--- a/Resources/Changelog/6MD.yml
+++ b/Resources/Changelog/6MD.yml
@@ -1,0 +1,3 @@
+Name: 6MD
+Order: 0
+Entries: []

--- a/Resources/Changelog/Monolith.yml
+++ b/Resources/Changelog/Monolith.yml
@@ -1,3 +1,4 @@
+Order: 1
 Entries:
 - author: Ark
   changes:

--- a/Resources/Locale/en-US/_Mono/changelog/changelog-window.ftl
+++ b/Resources/Locale/en-US/_Mono/changelog/changelog-window.ftl
@@ -1,1 +1,2 @@
 changelog-tab-title-Monolith = Monolith
+changelog-tab-title-6MD = 6MD


### PR DESCRIPTION
About the PR
This PR adds a dedicated 6MD changelog source and updates automation so PR changelog generation writes into the 6MD changelog file.

It also updates changelog tab presentation by adding a 6MD tab title localization and explicit ordering so changelog tabs appear as 6MD, then Monolith, then Upstream.

Additionally, the Discord changelog publish step in the publish workflow is disabled.

Why / Balance
This improves fork-specific changelog clarity for players and contributors by separating 6MD entries from Monolith and upstream streams while keeping all three visible in-game.

Gameplay balance is not changed. This is workflow/configuration and UI tab ordering only.

Media
No in-game visual/content asset changes requiring showcase media.

Requirements
 I have read relevant guidelines/documentation to this PR found on our devwiki.
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Open changelog in client and verify tabs include 6MD, Monolith, and Upstream in that order for non-admin users.
Confirm changelog.yml uses 6MD.yml as CHANGELOG_DIR.
Confirm publish.yml has the Discord changelog publish step disabled.
Optionally merge a test PR with a valid changelog block and verify entry lands in Resources/Changelog/6MD.yml.
Breaking changes
No breaking API, namespace, or prototype rename changes.

Changelog
:cl:

add: Added a dedicated 6MD changelog source and in-game changelog tab.
tweak: Changelog tab ordering now shows 6MD first, then Monolith, then Upstream.
tweak: PR changelog automation now writes to the 6MD changelog file.
remove: Disabled automatic Discord changelog publish step in the publish workflow.
