### PR TITLE
Refactor Power Pay Rate Calculation to Remove Deposit Cap

### DIFF
--- a/Content.Server/_NF/Power/EntitySystems/PowerTransmissionSystem.cs
+++ b/Content.Server/_NF/Power/EntitySystems/PowerTransmissionSystem.cs
@@ -133,7 +133,8 @@ public sealed partial class PowerTransmissionSystem : EntitySystem
         else
             depositValue = ent.Comp.LogarithmCoefficient * MathF.Pow(ent.Comp.LogarithmRateBase, MathF.Log10(power) - ent.Comp.LogarithmSubtrahend);
 
-        return MathF.Min(depositValue, ent.Comp.MaxValuePerSecond);
+        //return MathF.Min(depositValue, ent.Comp.MaxValuePerSecond);
+        return depositValue;
     }
 
     private void OnUIOpen(Entity<PowerTransmissionComponent> ent, ref AfterActivatableUIOpenEvent args)


### PR DESCRIPTION
About the PR
What did you change?

Refactor power pay rate calculation to remove the hard cap on the deposit value used in the pay-rate calculation.
This change updates the algorithm so pay scales with deposit value without being clamped at the previous cap.
High-level how the new code works:

The pay-rate calculation no longer clamps the deposit value to a maximum before computing the rate. Instead the raw (or otherwise adjusted) deposit value is used so larger deposits increase the pay rate accordingly.
The change is localized to [PowerTransmissionSystem.cs](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Why / Balance
Discuss how this would affect game balance or explain why it was changed:

This allows pay rates to scale more smoothly with deposit size. It removes an artificial ceiling that prevented higher deposits from yielding higher pay.
Expected balance impact: potential increase in rewards from very large deposits; maintainers may want to review if further tuning is required to avoid exploits or unexpected economy inflation.
Link any relevant discussions or issues:

(Add links here if there are related issues or design discussions)
Media
No media attached — this is a backend/gameplay calculation change.
Requirements
 I have read relevant guidelines/documentation to this PR found on [our devwiki](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Start the server and reproduce scenarios where the power deposit value influences pay-rate.
Compare pay-rate outputs for deposit values below and above the old cap:
For deposit values previously capped, verify the returned pay-rate is now higher (and scales) rather than being clamped.
Run any server-side unit or integration tests touching power/pay calculation (if present). Observe no regressions.
Sanity-check gameplay: ensure pay-rate scaling does not produce excessive values in normal play. If available, run a local scenario with large deposits and verify expected behavior.
Concrete test steps (example):

Spawn or configure an entity with a deposit value M (where M > previous cap).
Observe computed pay amount/rate in logs or via debugging output.
Repeat with M below the previous cap and ensure the relative change is correct.
Breaking changes
No breaking API or public class/name changes expected.
Behavioural change: pay-rate outcomes for some deposit sizes will differ (higher) than before. Consumers that implicitly depended on the old cap may need to be reviewed.
Changelog :cl:

tweak: Power pay rate calculation no longer caps deposit value; pay now scales with deposit value.