### PR TITLE
Set Default Temperature for Gas Mixture During Purchase Console Trans…

### DIFF
--- a/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
@@ -337,6 +337,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
 
         var mixture = new GasMixture();
         mixture.SetMoles(gasId, moles);
+        mixture.Temperature = 293.15f;
         _atmosphere.Merge(points[0].Comp.GasStorage, mixture);
 
         _audio.PlayPvs(ent.Comp.ApproveSound, ent);


### PR DESCRIPTION
…actions


## About the PR
changed gas temp at the purchase point to be 293.15 kelvin

## Why / Balance
it is a pain in the ass to mix gases when they are at different temps

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
buy gas from purchase point at edison

**Changelog**
:cl:
- tweak: gas temp on the gas buy point is now 293.15 kelvin

