### PR TITLE
Set Emergency Shuttle Auto-Call to 12 Hours

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -174,7 +174,7 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.Server | AdminFlags.Mapping, min: 0, max: int.MaxValue)]
     public static readonly CVarDef<int> EmergencyShuttleAutoCallTime =
-        CVarDef.Create("shuttle.auto_call_time", 360, CVar.SERVERONLY); // Frontier: 90<360
+        CVarDef.Create("shuttle.auto_call_time", 720, CVar.SERVERONLY); // Frontier: 90<360
 
     /// <summary>
     ///     Time in minutes after the round was extended (by recalling the shuttle) to call

--- a/Resources/ConfigPresets/_Mono/monolithCore.toml
+++ b/Resources/ConfigPresets/_Mono/monolithCore.toml
@@ -39,7 +39,7 @@ show_ooc_patron_color = false
 discord_channel_id = 1331042209172164639
 
 [shuttle]
-auto_call_time = 360
+auto_call_time = 720
 mass_limit = 0
 
 [surgery]


### PR DESCRIPTION
About the PR
Increases emergency shuttle auto-call from 6 hours to 12 hours (360 -> 720 minutes).

Updated:

Content.Shared/CCVar/CCVars.Shuttle.cs: default shuttle auto-call value changed to 720.
Resources/ConfigPresets/_Mono/monolithCore.toml: Monolith preset auto-call value changed to 720.
Why / Balance
This extends the default round duration window before automatic emergency shuttle call, allowing longer rounds and reducing forced early round endings from the default timer.

Media
Not required (config and default-value change only).

Requirements
 I have read relevant guidelines/documentation to this PR found on our devwiki.
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Start a server using the Monolith preset.
Check shuttle auto-call config value via admin var tools or config output.
Verify the value is 720 minutes (12h) for shuttle auto-call.
Confirm no other shuttle timing values were changed.
Breaking changes
None.

Changelog
:cl:

tweak: Increased emergency shuttle auto-call timing from 6 hours to 12 hours.