### PR TITLE
Fix: Restore Gravity on Ships After Shipyard Retrieve and Persistence…

### DIFF
--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -14,6 +14,7 @@ public sealed class GravityGeneratorSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<GravityGeneratorComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<GravityGeneratorComponent, EntParentChangedMessage>(OnParentChanged);
         SubscribeLocalEvent<GravityGeneratorComponent, ChargedMachineActivatedEvent>(OnActivated);
         SubscribeLocalEvent<GravityGeneratorComponent, ChargedMachineDeactivatedEvent>(OnDeactivated);
@@ -33,6 +34,32 @@ public sealed class GravityGeneratorSystem : EntitySystem
             _lights.SetRadius(uid, MathHelper.Lerp(grav.LightRadiusMin, grav.LightRadiusMax, charge.Charge),
                 pointLight);
         }
+    }
+
+    private void OnStartup(EntityUid uid, GravityGeneratorComponent component, ComponentStartup args)
+    {
+        if (!component.GravityActive)
+            return;
+
+        var xform = Transform(uid);
+
+        if (TryComp(xform.ParentUid, out GravityComponent? gravity))
+            _gravitySystem.RefreshGravity(xform.ParentUid, gravity);
+    }
+
+    public void ResyncGridGravity(EntityUid gridUid)
+    {
+        var query = EntityQueryEnumerator<GravityGeneratorComponent, PowerChargeComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var grav, out var charge, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            grav.GravityActive = charge.Active || (charge.Intact && charge.SwitchedOn && charge.Charge > 0f);
+        }
+
+        if (TryComp(gridUid, out GravityComponent? gravity))
+            _gravitySystem.RefreshGravity(gridUid, gravity);
     }
 
     private void OnActivated(Entity<GravityGeneratorComponent> ent, ref ChargedMachineActivatedEvent args)

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text.Json;
+using Content.Server.Gravity;
 using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
 using Content.Server.Shuttles.Components;
@@ -69,6 +70,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly SharedContainerSystem _containers = default!;
     [Dependency] private readonly ToggleableClothingSystem _toggleableClothingSystem = default!;
+    [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
 
     private readonly Dictionary<EntityUid, string> _gridToAnchor = new();
     private readonly Dictionary<string, EntityUid> _anchorToGrid = new();
@@ -364,6 +366,8 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
             if (!TryGetLiveAnchor(grid, anchorId, out var anchor, out var component))
                 continue;
+
+            _gravityGenerators.ResyncGridGravity(grid);
 
             SaveSnapshot(anchor, component, immediate: true);
             _pendingRestoreHealAnchors.Remove(anchorId);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -787,6 +787,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         }
 
         _shuttle.TryFTLDock(shuttleUid, shuttle, targetGrid.Value);
+        _gravityGenerators.ResyncGridGravity(shuttleUid);
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;
         var deedID = EnsureComp<ShuttleDeedComponent>(targetId);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Shuttles.Systems;
 using Content.Server.Shuttles.Components;
 using Content.Server.Station.Components;
 using Content.Server.Cargo.Systems;
+using Content.Server.Gravity;
 using Content.Server.Station.Systems;
 using Content.Shared._NF.Shipyard.Components;
 using Content.Shared._NF.Shipyard;
@@ -40,6 +41,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly ShipOwnershipSystem _shipOwnership = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
 
     public MapId? ShipyardMap { get; private set; }
     private float _shuttleIndex;


### PR DESCRIPTION
## About the PR

Fixes gravity generators failing to activate on ships loaded from the **shipyard retrieve** and **persistence anchor restore** flows.

**Root cause:** `PowerChargeComponent.Charge` is runtime-only state and resets to `0` on deserialization. After a ship grid loads, the generators come back `SwitchedOn` and `Intact` but with zero charge, so `ChargedMachineActivatedEvent` never fires and `GravityGeneratorComponent.GravityActive` stays `false`.

**Fix:** Added a `ResyncGridGravity(EntityUid gridUid)` method to `GravityGeneratorSystem` that recomputes generator gravity state from current `PowerChargeComponent` state and calls `RefreshGravity`. This is called explicitly in the two restore paths:
- `ShipyardSystem.Consoles.cs` — after `TryFTLDock` when retrieving a stored ship
- `PersistenceAnchorSystem.HealRestoredSnapshots()` — after persistent ships are restored at round start

## Why / Balance

Bug fix only. Ships with gravity generators that were stored in the shipyard or loaded from a persistence anchor would have no gravity despite showing as "on" — affecting all player-owned ships.

## Media

N/A — no visual changes; gravity is now simply present when it should be.

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

1. Buy and fit a ship with a gravity generator at a shipyard console
2. Store the ship via the shipyard console
3. Retrieve the ship — gravity should be active immediately without needing to toggle it
4. (Optional) Test persistence: save a ship, restart the round, confirm gravity works on load

## Breaking changes

None. New public method `GravityGeneratorSystem.ResyncGridGravity(EntityUid)` added, no existing APIs changed.

**Changelog**
:cl:
- fix: Gravity generators on ships now correctly restore gravity after being retrieved from the shipyard or loaded from a persistent anchor.