### PR TITLE
Fix: Restore Ship Shields After Shipyard and Persistence Reload

### DIFF
--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text.Json;
+using Content.Server._Crescent.ShipShields;
 using Content.Server.Gravity;
 using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
@@ -71,6 +72,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _containers = default!;
     [Dependency] private readonly ToggleableClothingSystem _toggleableClothingSystem = default!;
     [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
+    [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
 
     private readonly Dictionary<EntityUid, string> _gridToAnchor = new();
     private readonly Dictionary<string, EntityUid> _anchorToGrid = new();
@@ -368,6 +370,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
                 continue;
 
             _gravityGenerators.ResyncGridGravity(grid);
+            _shipShields.ResyncGridShields(grid);
 
             SaveSnapshot(anchor, component, immediate: true);
             _pendingRestoreHealAnchors.Remove(anchorId);

--- a/Content.Server/_Crescent/ShipShields/ShipShieldsSystem.cs
+++ b/Content.Server/_Crescent/ShipShields/ShipShieldsSystem.cs
@@ -111,6 +111,52 @@ public sealed partial class ShipShieldsSystem : EntitySystem
         InitializeEmitters();
     }
 
+    public void ResyncGridShields(EntityUid gridUid)
+    {
+        if (TryComp<ShipShieldedComponent>(gridUid, out var shielded) && !Exists(shielded.Shield))
+            RemComp<ShipShieldedComponent>(gridUid);
+
+        var query = EntityQueryEnumerator<ShipShieldEmitterComponent, ApcPowerReceiverComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var emitter, out var power, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            if (emitter.Shield is { } existingShield && !Exists(existingShield))
+                emitter.Shield = null;
+
+            if (emitter.Shielded is { } existingShielded && existingShielded != gridUid)
+                emitter.Shielded = null;
+
+            if (!power.Powered)
+            {
+                emitter.Recharging = true;
+            }
+            else if (emitter.Damage <= 0f && emitter.OverloadAccumulator <= 0f)
+            {
+                emitter.Recharging = false;
+            }
+
+            if ((emitter.Recharging || emitter.OverloadAccumulator > 0f) && emitter.Shield is not null)
+            {
+                UnshieldEntity(gridUid);
+                emitter.Shield = null;
+                emitter.Shielded = null;
+                continue;
+            }
+
+            if (!emitter.Recharging && emitter.Shield is null && emitter.OverloadAccumulator < 1f)
+            {
+                var shield = ShieldEntity(gridUid, uid);
+                if (shield != EntityUid.Invalid)
+                {
+                    emitter.Shield = shield;
+                    emitter.Shielded = gridUid;
+                }
+            }
+        }
+    }
+
 
     // Mono notes: THIS CODE BASICALLY DOES NOT WORK (especially for raycasted projectiles)
     private void OnCollide(EntityUid uid, ShipShieldComponent component, StartCollideEvent args)
@@ -188,7 +234,14 @@ public sealed partial class ShipShieldsSystem : EntitySystem
     private EntityUid ShieldEntity(EntityUid entity, EntityUid? source = null, MapGridComponent? mapGrid = null)
     {
         if (TryComp<ShipShieldedComponent>(entity, out var existingShielded))
-            return existingShielded.Shield;
+        {
+            // If the shield entity is valid and alive, return it.
+            if (Exists(existingShielded.Shield))
+                return existingShielded.Shield;
+
+            // Stale component from a pre-UnsavedComponent save snapshot — clear it and re-create.
+            RemComp<ShipShieldedComponent>(entity);
+        }
 
         if (!Resolve(entity, ref mapGrid, false))
             return EntityUid.Invalid;

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -788,6 +788,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
         _shuttle.TryFTLDock(shuttleUid, shuttle, targetGrid.Value);
         _gravityGenerators.ResyncGridGravity(shuttleUid);
+        _shipShields.ResyncGridShields(shuttleUid);
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;
         var deedID = EnsureComp<ShuttleDeedComponent>(targetId);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Shuttles.Systems;
 using Content.Server.Shuttles.Components;
 using Content.Server.Station.Components;
 using Content.Server.Cargo.Systems;
+using Content.Server._Crescent.ShipShields;
 using Content.Server.Gravity;
 using Content.Server.Station.Systems;
 using Content.Shared._NF.Shipyard.Components;
@@ -42,6 +43,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly ShipOwnershipSystem _shipOwnership = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
+    [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
 
     public MapId? ShipyardMap { get; private set; }
     private float _shuttleIndex;

--- a/Content.Shared/_Crescent/ShipShields/ShipShieldComponent.cs
+++ b/Content.Shared/_Crescent/ShipShields/ShipShieldComponent.cs
@@ -1,6 +1,6 @@
 namespace Content.Shared._Crescent.ShipShields;
 
-[RegisterComponent]
+[RegisterComponent, UnsavedComponent]
 public sealed partial class ShipShieldComponent : Component
 {
     public EntityUid? Source;

--- a/Content.Shared/_Crescent/ShipShields/ShipShieldedComponent.cs
+++ b/Content.Shared/_Crescent/ShipShields/ShipShieldedComponent.cs
@@ -1,6 +1,6 @@
 namespace Content.Shared._Crescent.ShipShields;
 
-[RegisterComponent]
+[RegisterComponent, UnsavedComponent]
 public sealed partial class ShipShieldedComponent : Component
 {
     public EntityUid Shield;


### PR DESCRIPTION
## About the PR
Fixes ship shield generators not reactivating after a ship is stored and then retrieved, including persistence-anchor restore flows. #17 

Root causes addressed:
- Runtime shield state components were being serialized into stored snapshots and could come back stale.
- Restore flows had an explicit gravity resync but no equivalent shield resync.
- Some retrieved ships could keep stale shield references, preventing shield recreation even after toggling power.

What changed:
- Added a shield resync pass for a restored grid that:
  - clears stale shield entity references
  - normalizes emitter state from current powered/recharging conditions
  - recreates the shield when conditions are valid
- Called shield resync in both restore paths:
  - Shipyard retrieve flow
  - Persistence anchor heal/restore flow
- Marked runtime-only shield state components as unsaved so they are not persisted into ship snapshots.

## Why / Balance
Bug fix only. This restores expected behavior for stored/retrieved ships and persistent ships so shields can come back online correctly.

## Media
No media required (logic/system fix only).

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Spawn or buy a ship with a shield emitter and power it.
2. Confirm shield activates.
3. Store the ship in shipyard.
4. Retrieve the same ship.
5. Confirm shield activates after retrieve.
6. Toggle shield power off/on and confirm normal behavior.
7. Restart round/server with persistence anchors and confirm restored ships can reactivate shields correctly.

## Breaking changes
No breaking API/prototype/name changes intended.

**Changelog**
:cl:
- fix: Ship shields now properly reactivate after shipyard retrieval and persistence-anchor ship restore.