### PR TITLE
Fix: Resync Device Networks on Ship Retrieve and Persistence Restore

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -261,6 +261,48 @@ namespace Content.Server.DeviceNetwork.Systems
         }
 
         /// <summary>
+        /// Re-applies map-init style network setup for all devices on a grid and reconnects them.
+        /// Used for ships restored from serialized snapshots where map-init hooks may have already been consumed.
+        /// </summary>
+        public void ResyncGridDeviceNetwork(EntityUid gridUid)
+        {
+            var query = EntityQueryEnumerator<DeviceNetworkComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var device, out var xform))
+            {
+                if (xform.GridUid != gridUid)
+                    continue;
+
+                if (device.ReceiveFrequency == null
+                    && device.ReceiveFrequencyId != null
+                    && _protoMan.TryIndex<DeviceFrequencyPrototype>(device.ReceiveFrequencyId, out var receive))
+                {
+                    device.ReceiveFrequency = receive.Frequency;
+                }
+
+                if (device.TransmitFrequency == null
+                    && device.TransmitFrequencyId != null
+                    && _protoMan.TryIndex<DeviceFrequencyPrototype>(device.TransmitFrequencyId, out var xmit))
+                {
+                    device.TransmitFrequency = xmit.Frequency;
+                }
+
+                if (!device.AutoConnect)
+                    continue;
+
+                if (IsDeviceConnected(uid, device))
+                    continue;
+
+                if (ConnectDevice(uid, device))
+                    continue;
+
+                if (device.CustomAddress)
+                    continue;
+
+                RandomizeAddress(uid, device);
+            }
+        }
+
+        /// <summary>
         ///     Try to find a device on a network using its address.
         /// </summary>
         private bool TryGetDevice(int netId, string address, [NotNullWhen(true)] out DeviceNetworkComponent? device) =>

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text.Json;
 using Content.Server._Crescent.ShipShields;
+using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Gravity;
 using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
@@ -73,6 +74,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     [Dependency] private readonly ToggleableClothingSystem _toggleableClothingSystem = default!;
     [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
     [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
+    [Dependency] private readonly DeviceNetworkSystem _deviceNetwork = default!;
 
     private readonly Dictionary<EntityUid, string> _gridToAnchor = new();
     private readonly Dictionary<string, EntityUid> _anchorToGrid = new();
@@ -369,6 +371,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
             if (!TryGetLiveAnchor(grid, anchorId, out var anchor, out var component))
                 continue;
 
+            _deviceNetwork.ResyncGridDeviceNetwork(grid);
             _gravityGenerators.ResyncGridGravity(grid);
             _shipShields.ResyncGridShields(grid);
 

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -787,6 +787,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         }
 
         _shuttle.TryFTLDock(shuttleUid, shuttle, targetGrid.Value);
+        _deviceNetwork.ResyncGridDeviceNetwork(shuttleUid);
         _gravityGenerators.ResyncGridGravity(shuttleUid);
         _shipShields.ResyncGridShields(shuttleUid);
 

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Shuttles.Components;
 using Content.Server.Station.Components;
 using Content.Server.Cargo.Systems;
 using Content.Server._Crescent.ShipShields;
+using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Gravity;
 using Content.Server.Station.Systems;
 using Content.Shared._NF.Shipyard.Components;
@@ -44,6 +45,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
     [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
+    [Dependency] private readonly DeviceNetworkSystem _deviceNetwork = default!;
 
     public MapId? ShipyardMap { get; private set; }
     private float _shuttleIndex;


### PR DESCRIPTION
About the PR
Fixes all signal-linked devices (blast doors, signallers, linked machines, etc.) stopping work after a ship is stored and retrieved via the shipyard or restored from persistence.
closes #14 
DeviceNetworkSystem registers devices in an in-memory _networks lookup table inside its OnMapInit handler. Ship snapshots serialize entities with mapInit: true, so when they are loaded back in, MapInitEvent does not re-fire — devices are fully deserialized with correct addresses and link data, but are never re-inserted into the runtime network tables. Every subsequent QueuePacket() call silently fails because IsAddressPresent returns false.

Fix: Added ResyncGridDeviceNetwork(EntityUid gridUid) to DeviceNetworkSystem. It walks every DeviceNetworkComponent on the grid, reapplies frequency values from their ID prototypes if null, and calls ConnectDevice() to register them back into the network. This is called in ShipyardSystem.Consoles.cs after a ship is retrieved and in PersistenceAnchorSystem.HealRestoredSnapshots() after a persistence restore — mirroring the existing ResyncGridGravity pattern.

Why / Balance
Bug fix only. No balance impact. Signal-linked devices on player-owned ships were non-functional after every store/retrieve cycle.

Media
N/A — internal system fix with no visual change.

Requirements
 I have read relevant guidelines/documentation to this PR found on our devwiki.
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Spawn a ship with blast doors or signal-linked devices.
Store the ship at a shipyard.
Retrieve the ship.
Verify blast doors toggle and signal switches work normally.
Breaking changes
None. ResyncGridDeviceNetwork is a new public method on DeviceNetworkSystem but no existing call sites are modified.

Changelog

:cl:

fix: Signal-linked devices (blast doors, switches, linked machines) on ships now correctly reconnect after shipyard retrieval or persistence restore.