### PR TITLE
Fix: Defer Toggleable Clothing Action Creation Until Runtime

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -492,8 +492,6 @@ public sealed class ToggleableClothingSystem : EntitySystem
 
         if (comp.ClothingUids.Count == 0)
             RebuildAttachedClothingMap(toggleable);
-
-        EnsureToggleAction(toggleable, comp);
     }
 
     private void OnAttachedInit(Entity<AttachedClothingComponent> attached, ref ComponentInit args)


### PR DESCRIPTION
About the PR
This fixes a regression in toggleable clothing initialization.

The recent toggleable clothing persistence fix caused toggle actions to be created during ComponentStartup. That meant uninitialized prototype spawns were gaining runtime-only action state before map init, which made prototype serialization differ from the prototype definition.

This change defers toggle action creation until runtime paths that actually need it, instead of creating it eagerly during startup. Normal runtime behavior is preserved, while uninitialized prototype spawns remain clean.

Why / Balance
This does not change balance. It fixes an initialization regression that caused integration failures and invalid prototype-save behavior for toggleable clothing entities such as hardsuits and winter coats.

Media
Not required.

Requirements
 I have read relevant guidelines/documentation to this PR found on our devwiki.
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Run the integration test suite with the project script:
Scripts/sh/runTestsIntegration.sh
Confirm PrototypeSaveTest.UninitializedSaveTest passes.
Confirm the full suite passes.
In game, verify toggleable clothing still provides its action normally once initialized.
Breaking changes
None.

Changelog
:cl:

fix: Fixed toggleable clothing creating runtime action state too early and failing prototype save validation.