### PR TITLE
Fix: Restore Expedition Consoles After Ship Storage

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -254,6 +254,32 @@ public sealed partial class SalvageSystem
         }
     }
 
+    public void ResyncGridExpeditionConsoles(EntityUid gridUid)
+    {
+        var hasConsole = false;
+        var query = EntityQueryEnumerator<SalvageExpeditionConsoleComponent, TransformComponent>();
+        while (query.MoveNext(out _, out _, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            hasConsole = true;
+            break;
+        }
+
+        if (!hasConsole)
+            return;
+
+        if (_station.GetOwningStation(gridUid) is not { Valid: true } stationUid)
+            return;
+
+        var data = EnsureComp<SalvageExpeditionDataComponent>(stationUid);
+        if (!data.Claimed && !data.Cooldown && data.Missions.Count == 0)
+            GenerateMissions(data);
+
+        UpdateConsoles(stationUid, data);
+    }
+
     private void UpdateConsole(Entity<SalvageExpeditionConsoleComponent> component)
     {
         var station = _station.GetOwningStation(component);

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Gravity;
 using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
+using Content.Server.Salvage;
 using Content.Server.Shuttles.Components;
 using Content.Server._Mono.Shuttles.Components;
 using Content.Server._Mono.TargetSeekingAlert;
@@ -75,6 +76,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
     [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetwork = default!;
+    [Dependency] private readonly SalvageSystem _salvage = default!;
 
     private readonly Dictionary<EntityUid, string> _gridToAnchor = new();
     private readonly Dictionary<string, EntityUid> _anchorToGrid = new();
@@ -371,9 +373,11 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
             if (!TryGetLiveAnchor(grid, anchorId, out var anchor, out var component))
                 continue;
 
+            _shipyard.EnsureRestoredShuttleStation(grid);
             _deviceNetwork.ResyncGridDeviceNetwork(grid);
             _gravityGenerators.ResyncGridGravity(grid);
             _shipShields.ResyncGridShields(grid);
+            _salvage.ResyncGridExpeditionConsoles(grid);
 
             SaveSnapshot(anchor, component, immediate: true);
             _pendingRestoreHealAnchors.Remove(anchorId);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -27,6 +27,7 @@ using Content.Shared.StationRecords;
 using Content.Server.Chat.Systems;
 using Content.Server.Mind;
 using Content.Server.Preferences.Managers;
+using Content.Server.Salvage;
 using Content.Server.StationRecords;
 using Content.Server.StationRecords.Systems;
 using Content.Shared.Database;
@@ -787,9 +788,11 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         }
 
         _shuttle.TryFTLDock(shuttleUid, shuttle, targetGrid.Value);
+        _ = EnsureRestoredShuttleStation(shuttleUid);
         _deviceNetwork.ResyncGridDeviceNetwork(shuttleUid);
         _gravityGenerators.ResyncGridGravity(shuttleUid);
         _shipShields.ResyncGridShields(shuttleUid);
+        _salvage.ResyncGridExpeditionConsoles(shuttleUid);
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;
         var deedID = EnsureComp<ShuttleDeedComponent>(targetId);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Cargo.Systems;
 using Content.Server._Crescent.ShipShields;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Gravity;
+using Content.Server.Salvage;
 using Content.Server.Station.Systems;
 using Content.Shared._NF.Shipyard.Components;
 using Content.Shared._NF.Shipyard;
@@ -26,6 +27,7 @@ using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.Utility;
 using Content.Shared.Doors.Components;
 using Robust.Shared.Map.Components;
+using Content.Shared.Salvage.Expeditions;
 
 namespace Content.Server._NF.Shipyard.Systems;
 
@@ -46,6 +48,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
     [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetwork = default!;
+    [Dependency] private readonly SalvageSystem _salvage = default!;
 
     public MapId? ShipyardMap { get; private set; }
     private float _shuttleIndex;
@@ -359,7 +362,12 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return null;
 
         if (_station.GetOwningStation(shuttleUid) is { Valid: true } existingStation)
+        {
+            if (GridHasExpeditionConsole(shuttleUid))
+                EnsureComp<SalvageExpeditionDataComponent>(existingStation);
+
             return existingStation;
+        }
 
         if (!TryComp<ShuttleDeedComponent>(shuttleUid, out var deed))
             return null;
@@ -378,7 +386,22 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _metaData.SetEntityName(stationUid, stationName);
         _station.AddGridToStation(stationUid, shuttleUid, name: stationName);
 
+        if (GridHasExpeditionConsole(shuttleUid))
+            EnsureComp<SalvageExpeditionDataComponent>(stationUid);
+
         return stationUid;
+    }
+
+    private bool GridHasExpeditionConsole(EntityUid shuttleUid)
+    {
+        var query = EntityQueryEnumerator<SalvageExpeditionConsoleComponent, TransformComponent>();
+        while (query.MoveNext(out _, out _, out var xform))
+        {
+            if (xform.GridUid == shuttleUid)
+                return true;
+        }
+
+        return false;
     }
 
     // <summary>


### PR DESCRIPTION
About the PR
This fixes expedition consoles not working after a ship is stored and then retrieved.

The root issue was that restored shuttle stations were being recreated without SalvageExpeditionData, so expedition consoles came back attached to a station with no expedition state. This change detects restored shuttles that contain expedition consoles, restores the required station-side expedition data, and resyncs expedition console UI/state after both shipyard retrieval and persistence restore.

Closes #25

Why / Balance
This does not change balance. It fixes broken expedition console behavior on stored/retrieved ships by restoring the runtime station data those consoles depend on.

Media
Not required.

Requirements
 I have read relevant guidelines/documentation to this PR found on our devwiki.
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Spawn or purchase a ship with an expedition console.
Verify the expedition console works normally before storage.
Store the ship, then retrieve it from shipyard storage.
Verify the expedition console still shows expedition data and functions after retrieval.
Optionally verify a persistence-restore flow also preserves expedition console functionality.
Breaking changes
None.

Changelog
:cl:

fix: Fixed expedition consoles not working after ships were stored and retrieved.