### PR TITLE
Fix: Restore Shuttle Jobs and Crew Latejoin Metadata

### DIFF
--- a/Content.Server/Station/Systems/StationJobsSystem.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.cs
@@ -49,6 +49,9 @@ public sealed partial class StationJobsSystem : EntitySystem
 
     private void OnInit(Entity<StationJobsComponent> ent, ref ComponentInit args)
     {
+        if (ent.Comp.SetupAvailableJobs == null)
+            ent.Comp.SetupAvailableJobs = new();
+
         ent.Comp.MidRoundTotalJobs = ent.Comp.SetupAvailableJobs.Values
             .Select(x => Math.Max(x[1], 0))
             .Sum();
@@ -561,6 +564,38 @@ public sealed partial class StationJobsSystem : EntitySystem
     public void UpdateJobsAvailable() // Frontier: private<public
     {
         _availableJobsDirty = true;
+    }
+
+    /// <summary>
+    /// Sets up default jobs (Contractor, Pilot, Mercenary) for a restored or purchased ship.
+    /// </summary>
+    public void SetDefaultShipJobs(EntityUid station, StationJobsComponent? stationJobs = null)
+    {
+        if (!Resolve(station, ref stationJobs, false))
+            return;
+
+        // Default jobs for purchased/restored ships
+        // Format: [startSlots, midRoundSlots] where 0 means unlimited
+        stationJobs.SetupAvailableJobs["Contractor"] = new[] { 0, 0 };
+        stationJobs.SetupAvailableJobs["Pilot"] = new[] { 0, 0 };
+        stationJobs.SetupAvailableJobs["Mercenary"] = new[] { 0, 0 };
+
+        // Re-initialize the job list from setup
+        stationJobs.JobList = stationJobs.SetupAvailableJobs.ToDictionary(
+            x => x.Key,
+            x => x.Value[1] < 0 ? null : (int?)x.Value[1]);
+
+        stationJobs.MidRoundTotalJobs = stationJobs.SetupAvailableJobs.Values
+            .Select(x => Math.Max(x[1], 0))
+            .Sum();
+
+        stationJobs.OverflowJobs = stationJobs.SetupAvailableJobs
+            .Where(x => x.Value[0] < 0)
+            .Select(x => x.Key)
+            .ToHashSet();
+
+        stationJobs.TotalJobs = stationJobs.JobList.Values.Select(x => x ?? 0).Sum();
+        UpdateJobsAvailable();
     }
 
     private void OnPlayerJoinedLobby(PlayerJoinedLobbyEvent ev)

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -28,6 +28,9 @@ using Robust.Shared.Utility;
 using Content.Shared.Doors.Components;
 using Robust.Shared.Map.Components;
 using Content.Shared.Salvage.Expeditions;
+using Content.Server.StationRecords;
+using Content.Server.Station.Components;
+using Content.Server._NF.Station.Components;
 
 namespace Content.Server._NF.Shipyard.Systems;
 
@@ -49,6 +52,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetwork = default!;
     [Dependency] private readonly SalvageSystem _salvage = default!;
+    [Dependency] private readonly StationJobsSystem _stationJobs = default!;
 
     public MapId? ShipyardMap { get; private set; }
     private float _shuttleIndex;
@@ -361,16 +365,22 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         if (!HasComp<ShuttleComponent>(shuttleUid))
             return null;
 
+        if (!TryComp<ShuttleDeedComponent>(shuttleUid, out var deed))
+            return null;
+
         if (_station.GetOwningStation(shuttleUid) is { Valid: true } existingStation)
         {
             if (GridHasExpeditionConsole(shuttleUid))
                 EnsureComp<SalvageExpeditionDataComponent>(existingStation);
 
+            EnsureComp<StationRecordsComponent>(existingStation);
+            EnsureComp<StationJobsComponent>(existingStation);
+            _stationJobs.SetDefaultShipJobs(existingStation);
+
+            EnsureComp<ExtraShuttleInformationComponent>(existingStation);
+
             return existingStation;
         }
-
-        if (!TryComp<ShuttleDeedComponent>(shuttleUid, out var deed))
-            return null;
 
         var stationName = GetFullName(deed);
         if (string.IsNullOrWhiteSpace(stationName))
@@ -388,6 +398,12 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
         if (GridHasExpeditionConsole(shuttleUid))
             EnsureComp<SalvageExpeditionDataComponent>(stationUid);
+
+        EnsureComp<StationRecordsComponent>(stationUid);
+        EnsureComp<StationJobsComponent>(stationUid);
+        _stationJobs.SetDefaultShipJobs(stationUid);
+
+        EnsureComp<ExtraShuttleInformationComponent>(stationUid);
 
         return stationUid;
     }


### PR DESCRIPTION
About the PR
This fixes restored shuttle stations so they behave like purchased vessels after retrieval.
It ensures restored shuttle stations have the expected records and jobs backing data, restores default ship jobs, and marks restored ships as vessel entries so they appear in the crew section of latejoin instead of station.

Why / Balance
This is a functionality fix for persistence and retrieval flow.
No balance changes are introduced; it restores intended behavior that existed when ships are first purchased.

Media
N/A, this is a backend/system fix with no visual content requirements.

Requirements
 I have read relevant guidelines/documentation to this PR found on our devwiki.
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Start server and load into a round with shipyard available.
Store a player vessel through shipyard retrieval flow.
Retrieve the ship.
Confirm station records computer opens and functions without station/jobs exceptions.
Open latejoin and verify restored ship appears under crew/vessel listings, not station.
Confirm default vessel jobs are available on the restored ship (Contractor, Pilot, Mercenary).
Breaking changes
None.

Changelog
:cl:

fix: Fixed restored ships losing station records and vessel job setup after retrieval.
fix: Fixed restored ships appearing under station instead of crew in latejoin.