### PR TITLE
Fix Ship Restore Dispenser and Spreader Serialization

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Chemistry.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<ReagentDispenserComponent, ComponentStartup>(SubscribeUpdateUiState);
+            SubscribeLocalEvent<ReagentDispenserComponent, ComponentStartup>(OnDispenserStartup);
             SubscribeLocalEvent<ReagentDispenserComponent, SolutionContainerChangedEvent>(SubscribeUpdateUiState);
             SubscribeLocalEvent<ReagentDispenserComponent, EntInsertedIntoContainerMessage>(OnEntInserted); // Frontier: SubscribeUpdateUiState < OnEntInserted
             SubscribeLocalEvent<ReagentDispenserComponent, EntRemovedFromContainerMessage>(SubscribeUpdateUiState);
@@ -59,6 +59,7 @@ namespace Content.Server.Chemistry.EntitySystems
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserDispenseReagentMessage>(OnDispenseReagentMessage);
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserClearContainerSolutionMessage>(OnClearContainerSolutionMessage);
 
+            SubscribeLocalEvent<ReagentDispenserComponent, ComponentInit>(OnDispenserInit); // FIX: Recreate slots when loaded from save
             SubscribeLocalEvent<ReagentDispenserComponent, MapInitEvent>(OnMapInit, before: new []{typeof(ItemSlotsSystem)});
         }
 
@@ -235,6 +236,75 @@ namespace Content.Server.Chemistry.EntitySystems
         }
 
         /// <summary>
+        /// FIX: Initialize dispenser slots when component initializes.
+        /// For dispensers loaded from save (where slots were cleared), this recreates them.
+        /// For fresh spawns, MapInit/RefreshParts already handled it.
+        /// </summary>
+        private void OnDispenserInit(EntityUid uid, ReagentDispenserComponent component, ComponentInit args)
+        {
+            // If slots are empty (loaded from save with cleared slots), trigger RefreshParts
+            if (component.StorageSlots.Count == 0)
+            {
+                // Create default part ratings - base parts (rating 1.0)
+                var partRatings = new Dictionary<string, float>
+                {
+                    { component.SlotUpgradeMachinePart, 1.0f }
+                };
+                
+                // Trigger RefreshParts to create the slots
+                var ev = new RefreshPartsEvent { PartRatings = partRatings };
+                RaiseLocalEvent(uid, ev);
+            }
+        }
+
+        private void OnDispenserStartup(EntityUid uid, ReagentDispenserComponent component, ComponentStartup args)
+        {
+            var slotCount = Math.Max(component.NumSlots, Math.Max(component.StorageSlots.Count, component.StorageSlotIds.Count));
+            if (slotCount == 0)
+            {
+                UpdateUiState((uid, component));
+                return;
+            }
+
+            if (slotCount > component.NumSlots)
+                component.NumSlots = slotCount;
+
+            for (var i = 0; i < slotCount; i++)
+            {
+                var storageSlotId = ReagentDispenserComponent.BaseStorageSlotId + i;
+
+                if (i >= component.StorageSlotIds.Count)
+                    component.StorageSlotIds.Add(storageSlotId);
+                else
+                    component.StorageSlotIds[i] = storageSlotId;
+
+                if (i >= component.StorageSlots.Count)
+                {
+                    component.StorageSlots.Add(new ItemSlot
+                    {
+                        Whitelist = component.StorageWhitelist,
+                        Swap = false,
+                        EjectOnBreak = true,
+                    });
+                }
+
+                var slot = component.StorageSlots[i];
+                slot.Name = "Storage Slot " + (i + 1);
+
+                if (_itemSlotsSystem.TryGetSlot(uid, storageSlotId, out var existingSlot))
+                {
+                    _itemSlotsSystem.RebindItemSlot(uid, storageSlotId, existingSlot);
+                    component.StorageSlots[i] = existingSlot;
+                    continue;
+                }
+
+                _itemSlotsSystem.RebindItemSlot(uid, storageSlotId, slot);
+            }
+
+            UpdateUiState((uid, component));
+        }
+
+        /// <summary>
         /// Automatically generate storage slots for all NumSlots, and fill them with their initial chemicals.
         /// The actual spawning of entities happens in ItemSlotsSystem's MapInit.
         /// </summary>
@@ -274,16 +344,91 @@ namespace Content.Server.Chemistry.EntitySystems
 
             _itemSlotsSystem.AddItemSlot(uid, SharedReagentDispenser.OutputSlotName, component.BeakerSlot);
 
+            // Restore path can deserialize container contents but leave slot registration/state out of sync.
+            // Rebuild slot registration from the serialized slot/container data.
+            var slotCount = Math.Max(component.NumSlots, Math.Max(component.StorageSlots.Count, component.StorageSlotIds.Count));
+            if (slotCount > component.NumSlots)
+                component.NumSlots = slotCount;
+
+            for (var i = 0; i < slotCount; i++)
+            {
+                var storageSlotId = ReagentDispenserComponent.BaseStorageSlotId + i;
+
+                // Keep serialized id list in sync with expected ids.
+                if (i >= component.StorageSlotIds.Count)
+                    component.StorageSlotIds.Add(storageSlotId);
+                else
+                    component.StorageSlotIds[i] = storageSlotId;
+
+                ItemSlot storageSlot;
+                if (i < component.StorageSlots.Count)
+                {
+                    storageSlot = component.StorageSlots[i];
+                }
+                else
+                {
+                    storageSlot = new ItemSlot
+                    {
+                        Whitelist = component.StorageWhitelist,
+                        Swap = false,
+                        EjectOnBreak = true,
+                    };
+
+                    component.StorageSlots.Add(storageSlot);
+                }
+
+                storageSlot.Name = "Storage Slot " + (i + 1);
+
+                if (_itemSlotsSystem.TryGetSlot(uid, storageSlotId, out var existingSlot))
+                {
+                    // Only force rebind if the slot is actually broken.
+                    // Re-registering healthy slots triggers duplicate-key logs on normal map loads.
+                    if (existingSlot.ContainerSlot == null)
+                    {
+                        _itemSlotsSystem.AddItemSlot(uid, storageSlotId, existingSlot);
+                    }
+
+                    component.StorageSlots[i] = existingSlot;
+
+                    continue;
+                }
+                _itemSlotsSystem.AddItemSlot(uid, storageSlotId, storageSlot);
+            }
+
+            // If slots already contain items (e.g. restored from ship snapshot),
+            // do not spawn pack contents again.
+            var hasLoadedInventory = false;
+            for (var i = 0; i < component.NumSlots; i++)
+            {
+                var storageSlotId = ReagentDispenserComponent.BaseStorageSlotId + i;
+                if (_itemSlotsSystem.GetItemOrNull(uid, storageSlotId) is { Valid: true })
+                {
+                    hasLoadedInventory = true;
+                    break;
+                }
+
+                if (_containers.TryGetContainer(uid, storageSlotId, out var container)
+                    && container is ContainerSlot slot
+                    && slot.ContainedEntity is { Valid: true })
+                {
+                    hasLoadedInventory = true;
+                    break;
+                }
+            }
+
             // Frontier: spawn slot contents
-            if (component.PackPrototypeId is not null
+            if (!hasLoadedInventory
+                && component.PackPrototypeId is not null
                 && _prototypeManager.TryIndex(component.PackPrototypeId, out ReagentDispenserInventoryPrototype? packPrototype))
             {
-                for (var i = 0; i < packPrototype.Inventory.Count && i < component.StorageSlots.Count; i++)
+                for (var i = 0; i < packPrototype.Inventory.Count && i < component.NumSlots; i++)
                 {
-                    if (component.StorageSlots[i].ContainerSlot == null)
+                    var storageSlotId = ReagentDispenserComponent.BaseStorageSlotId + i;
+                    if (!_itemSlotsSystem.TryGetSlot(uid, storageSlotId, out var slot) || slot.ContainerSlot == null)
                         continue;
+
                     var item = Spawn(packPrototype.Inventory[i], Transform(uid).Coordinates);
-                    if (!_containers.Insert(item, component.StorageSlots[i].ContainerSlot!)) // ContainerSystem.Insert is silent.
+                    if (!_containers.Insert(item, slot.ContainerSlot)) // ContainerSystem.Insert is silent.
                         QueueDel(item);
                 }
             }

--- a/Content.Server/Spreader/SpreaderGridComponent.cs
+++ b/Content.Server/Spreader/SpreaderGridComponent.cs
@@ -14,5 +14,5 @@ public sealed partial class SpreaderGridComponent : Component
     public float UpdateSpacing = 1f;
 
     [DataField]
-    public Dictionary<ProtoId<EdgeSpreaderPrototype>, Queue<Entity<EdgeSpreaderComponent>>> SpreadQueues = new();
+    public Dictionary<ProtoId<EdgeSpreaderPrototype>, Queue<EntityUid>> SpreadQueues = new();
 }

--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -116,7 +116,7 @@ public sealed class SpreaderSystem : EntitySystem
         if (_spreaderGridQuery.TryComp(xform.GridUid, out var spreaderGrid)
             && _spreaderQuery.TryComp(spreader, out var comp))
         {
-            spreaderGrid.SpreadQueues[comp.Id].Enqueue((spreader, comp));
+            spreaderGrid.SpreadQueues[comp.Id].Enqueue(spreader);
         }
     }
 
@@ -137,7 +137,7 @@ public sealed class SpreaderSystem : EntitySystem
             if (!_spreaderQuery.TryComp(ent, out var spreader))
                 continue;
 
-            spreaderGrid.SpreadQueues[spreader.Id].Enqueue((ent, spreader));
+            spreaderGrid.SpreadQueues[spreader.Id].Enqueue(ent);
         }
     }
 
@@ -167,22 +167,25 @@ public sealed class SpreaderSystem : EntitySystem
                 var count = spreadQueue.Count;
                 for (var i = 0; i < count && updates > 0; i++)
                 {
-                    var ent = spreadQueue.Dequeue();
+                    var entUid = spreadQueue.Dequeue();
 
-                    if (TerminatingOrDeleted(ent) || !_activeQuery.HasComp(ent))
+                    if (TerminatingOrDeleted(entUid) || !_activeQuery.HasComp(entUid))
                         continue;
 
-                    var xform = Transform(ent);
+                    if (!_spreaderQuery.TryComp(entUid, out var spreaderComp))
+                        continue;
+
+                    var xform = Transform(entUid);
                     if (xform.GridUid != gridUid)
                     {
-                        InitSpreader(ent);
+                        InitSpreader(entUid);
                         continue;
                     }
 
                     // try to update the specified amount of active spreaders
-                    Spread(ent, (gridUid, mapGrid), xform, spacedSpread, ref updates);
+                    Spread((entUid, spreaderComp), (gridUid, mapGrid), xform, spacedSpread, ref updates);
 
-                    spreadQueue.Enqueue(ent); // requeue it
+                    spreadQueue.Enqueue(entUid); // requeue it
                 }
             }
         }

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -115,6 +115,21 @@ namespace Content.Shared.Containers.ItemSlots
         }
 
         /// <summary>
+        ///     Rebind an existing item slot to the current container manager container for its id.
+        ///     This is useful for entities loaded at runtime where deserialization may replace container instances
+        ///     after a slot wrapper was created.
+        /// </summary>
+        public void RebindItemSlot(EntityUid uid, string id, ItemSlot slot, ItemSlotsComponent? itemSlots = null)
+        {
+            itemSlots ??= EnsureComp<ItemSlotsComponent>(uid);
+            DebugTools.AssertOwner(uid, itemSlots);
+
+            slot.ContainerSlot = _containers.EnsureContainer<ContainerSlot>(uid, id);
+            itemSlots.Slots[id] = slot;
+            Dirty(uid, itemSlots);
+        }
+
+        /// <summary>
         ///     Remove an item slot. This should generally be called whenever a component that added a slot is being
         ///     removed.
         /// </summary>


### PR DESCRIPTION
## About the PR
Fixes two persistence-related issues affecting stored and restored ships.

First, this fixes reagent dispensers coming back empty after a ship is stored and then reloaded mid-round. The saved YAML already contained the dispenser slot/container state, but the live item-slot wrappers were not reliably rebound to the deserialized container slots on runtime load. This PR adds explicit slot recovery and rebind handling for reagent dispensers during init/startup so restored storage slots point back at the loaded jugs instead of behaving as empty.

Second, this fixes ship save serialization errors caused by `SpreaderGridComponent` storing `Entity<EdgeSpreaderComponent>` values in queued spreader state. Those are now stored as `EntityUid`, and the spreader system resolves the component when processing the queue. This avoids serializer exceptions during grid save.

Closes #24

## Why / Balance
This is a bugfix PR.

Stored ships should restore with the same functional machine state they had when stored. Chemical dispensers losing their loaded jugs breaks expected persistence behavior and makes ship storage unreliable. The spreader serialization fix also prevents ship save/load from being disrupted by unrelated serializer failures.

## Media
Not required.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Purchase a Hammerhead or another ship containing a chemical dispenser.
2. Verify the dispenser loads normally and does not produce duplicate item-slot errors on purchase.
3. Load custom chemical jugs into the dispenser.
4. Store the ship with the shipyard console.
5. Retrieve the stored ship mid-round.
6. Verify the dispenser still contains the same loaded jugs and dispenses correctly.
7. Verify ship storage no longer logs spreader serialization errors during save.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed chemical dispensers on stored ships restoring empty after ship retrieval.
- fix: Fixed spreader grid state causing serializer errors during ship save.