### PR TITLE
Fix: Restore Ship Weapons Firing After Persist/Retrieve

### DIFF
--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -8,6 +8,29 @@ namespace Content.Server.Power.EntitySystems
 {
     public sealed class ExtensionCableSystem : EntitySystem
     {
+        public void ResyncGridConnections(EntityUid gridUid)
+        {
+            var providerQuery = EntityQueryEnumerator<ExtensionCableProviderComponent>();
+            while (providerQuery.MoveNext(out var uid, out var provider))
+            {
+                if (Transform(uid).GridUid != gridUid)
+                    continue;
+
+                Disconnect(uid, provider);
+                Connect(uid, provider);
+            }
+
+            var receiverQuery = EntityQueryEnumerator<ExtensionCableReceiverComponent>();
+            while (receiverQuery.MoveNext(out var uid, out var receiver))
+            {
+                if (Transform(uid).GridUid != gridUid)
+                    continue;
+
+                Disconnect(uid, receiver);
+                Connect(uid, receiver);
+            }
+        }
+
         public override void Initialize()
         {
             base.Initialize();

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -8,8 +8,10 @@ using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Gravity;
 using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
+using Content.Server.Power.EntitySystems;
 using Content.Server.Salvage;
 using Content.Server.Shuttles.Components;
+using Content.Server._Mono.FireControl;
 using Content.Server._Mono.Shuttles.Components;
 using Content.Server._Mono.TargetSeekingAlert;
 using Content.Server._NF.Station.Systems;
@@ -76,7 +78,9 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
     [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetwork = default!;
+    [Dependency] private readonly ExtensionCableSystem _extensionCables = default!;
     [Dependency] private readonly SalvageSystem _salvage = default!;
+    [Dependency] private readonly FireControlSystem _fireControl = default!;
 
     private readonly Dictionary<EntityUid, string> _gridToAnchor = new();
     private readonly Dictionary<string, EntityUid> _anchorToGrid = new();
@@ -375,9 +379,11 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
             _shipyard.EnsureRestoredShuttleStation(grid);
             _deviceNetwork.ResyncGridDeviceNetwork(grid);
+            _extensionCables.ResyncGridConnections(grid);
             _gravityGenerators.ResyncGridGravity(grid);
             _shipShields.ResyncGridShields(grid);
             _salvage.ResyncGridExpeditionConsoles(grid);
+            _fireControl.ResyncGridFireControl(grid);
 
             SaveSnapshot(anchor, component, immediate: true);
             _pendingRestoreHealAnchors.Remove(anchorId);

--- a/Content.Server/_Mono/FireControl/FireControlSystem.Console.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.Console.cs
@@ -130,7 +130,15 @@ public sealed partial class FireControlSystem : EntitySystem
         if (component.ConnectedServer == null
             || !TryComp<FireControlServerComponent>(component.ConnectedServer, out var server)
             || !server.Consoles.Contains(uid))
-            return;
+        {
+            // Self-heal stale console bindings (common after restore) before rejecting fire input.
+            DoRefreshServer(uid, component);
+
+            if (component.ConnectedServer == null
+                || !TryComp<FireControlServerComponent>(component.ConnectedServer, out server)
+                || !server.Consoles.Contains(uid))
+                return;
+        }
 
         var xform = Transform(uid);
         var grid = xform.GridUid;

--- a/Content.Server/_Mono/FireControl/FireControlSystem.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.cs
@@ -20,6 +20,8 @@ using Content.Shared.Interaction;
 using Content.Shared._Mono.ShipGuns;
 using Content.Shared.Examine;
 using Content.Server.Salvage.Expeditions;
+using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Log;
 
 namespace Content.Server._Mono.FireControl;
 
@@ -207,7 +209,7 @@ public sealed partial class FireControlSystem : EntitySystem
 
         while (query.MoveNext(out var controllable, out var controlComp))
         {
-            if (_xform.GetGrid(controllable) == grid && EntityManager.GetComponent<TransformComponent>(controllable).Anchored)
+            if (_xform.GetGrid(controllable) == grid)
                 TryRegister(controllable, controlComp);
         }
 
@@ -379,6 +381,91 @@ public sealed partial class FireControlSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    /// Rebuilds fire control server and console bindings on a specific grid.
+    /// </summary>
+    public void ResyncGridFireControl(EntityUid gridUid)
+    {
+        CleanupInvalidServerReferences();
+
+        var controllableQuery = EntityQueryEnumerator<FireControllableComponent>();
+        while (controllableQuery.MoveNext(out var controllableUid, out var controllable))
+        {
+            if (_xform.GetGrid(controllableUid) != gridUid)
+                continue;
+
+            // Runtime state can be stale after persistence restore.
+            controllable.ControllingServer = null;
+            controllable.NextFire = TimeSpan.Zero;
+
+            if (TryComp<GunComponent>(controllableUid, out var gunComp))
+            {
+                gunComp.NextFire = TimeSpan.Zero;
+                gunComp.ShotCounter = 0;
+                gunComp.BurstActivated = false;
+                gunComp.BurstShotsCount = 0;
+                gunComp.ShootCoordinates = null;
+                gunComp.Target = null;
+                // FireRateModified (and other *Modified fields) are not serialized; they must be
+                // recalculated after restore, otherwise all AttemptShoot calls are blocked.
+                _gun.RefreshModifiers((controllableUid, gunComp));
+            }
+
+            // Auto-fire guns can remain stuck disabled after restore without a fresh anchor/power event.
+            if (TryComp<AutoShootGunComponent>(controllableUid, out var autoShoot))
+            {
+                if (_gun.CanEnable(controllableUid, autoShoot))
+                    _gun.EnableGun(controllableUid, autoShoot);
+                else
+                    _gun.DisableGun(controllableUid, autoShoot);
+            }
+        }
+
+        var serversOnGrid = new List<EntityUid>();
+        var serverQuery = EntityQueryEnumerator<FireControlServerComponent>();
+
+        while (serverQuery.MoveNext(out var serverUid, out _))
+        {
+            if (_xform.GetGrid(serverUid) == gridUid)
+                serversOnGrid.Add(serverUid);
+        }
+
+        // Hard-reset server bindings so stale controlled weapon state is rebuilt after restore.
+        foreach (var serverUid in serversOnGrid)
+        {
+            if (!TryComp<FireControlServerComponent>(serverUid, out var serverComp))
+                continue;
+
+            Disconnect(serverUid, serverComp);
+        }
+
+        foreach (var serverUid in serversOnGrid)
+        {
+            if (!Exists(serverUid)
+                || !_power.IsPowered(serverUid)
+                || !TryComp<FireControlServerComponent>(serverUid, out var serverComp))
+                continue;
+
+            TryConnect(serverUid, serverComp);
+        }
+
+        if (TryComp<FireControlGridComponent>(gridUid, out var controlGrid)
+            && controlGrid.ControllingServer != null)
+        {
+            RefreshControllables(gridUid, controlGrid);
+        }
+
+        var consoleQuery = EntityQueryEnumerator<FireControlConsoleComponent>();
+
+        while (consoleQuery.MoveNext(out var consoleUid, out var console))
+        {
+            if (_xform.GetGrid(consoleUid) != gridUid)
+                continue;
+
+            DoRefreshServer(consoleUid, console);
+        }
+    }
+
     public bool CanFireWeapons(EntityUid grid)
     {
         if (TerminatingOrDeleted(grid)
@@ -410,8 +497,15 @@ public sealed partial class FireControlSystem : EntitySystem
         foreach (var weapon in weapons)
         {
             var localWeapon = GetEntity(weapon);
-            if (!Exists(localWeapon) || !component.Controlled.Contains(localWeapon))
+            if (!Exists(localWeapon))
+            {
                 continue;
+            }
+
+            if (!component.Controlled.Contains(localWeapon))
+            {
+                continue;
+            }
 
             var fired = AttemptFire(localWeapon, localWeapon, targetCoords);
 
@@ -492,13 +586,17 @@ public sealed partial class FireControlSystem : EntitySystem
         var direction = targetPos - weaponPos;
         var distance = direction.Length();
         if (distance <= float.Epsilon)
+        {
             return false; // Can't fire at the same position
+        }
 
         direction = Vector2.Normalize(direction);
 
         // Check for obstacles in the firing direction
         if (!CanFireInDirection(weapon, weaponPos, direction, targetPos, weaponXform.MapID))
+        {
             return false;
+        }
 
         // Set the cooldown for next firing
         comp.NextFire = _timing.CurTime + TimeSpan.FromSeconds(comp.FireCooldown);
@@ -526,15 +624,21 @@ public sealed partial class FireControlSystem : EntitySystem
     {
         // Check if weapon is powered
         if (!_power.IsPowered(weapon))
+        {
             return false;
+        }
 
         // Check if weapon is connected to a server
         if (comp.ControllingServer == null && !noServer)
+        {
             return false;
+        }
 
         // Check for other conditions like cooldowns if needed
         if (comp.NextFire > _timing.CurTime)
+        {
             return false;
+        }
 
         return true;
     }

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -55,6 +55,7 @@ using Content.Shared.Tag;
 using Robust.Shared.EntitySerialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Server._Mono.FireControl;
 
 namespace Content.Server._NF.Shipyard.Systems;
 
@@ -81,6 +82,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly PersistenceAnchorSystem _persistenceAnchor = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
+    [Dependency] private readonly FireControlSystem _fireControl = default!;
 
     private static readonly ProtoId<TagPrototype> CrewedShuttleTag = "CrewedShuttle";
     private static readonly Regex DeedRegex = new(@"\s*\([^()]*\)");
@@ -790,9 +792,11 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _shuttle.TryFTLDock(shuttleUid, shuttle, targetGrid.Value);
         _ = EnsureRestoredShuttleStation(shuttleUid);
         _deviceNetwork.ResyncGridDeviceNetwork(shuttleUid);
+        _extensionCables.ResyncGridConnections(shuttleUid);
         _gravityGenerators.ResyncGridGravity(shuttleUid);
         _shipShields.ResyncGridShields(shuttleUid);
         _salvage.ResyncGridExpeditionConsoles(shuttleUid);
+        _fireControl.ResyncGridFireControl(shuttleUid);
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;
         var deedID = EnsureComp<ShuttleDeedComponent>(targetId);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Cargo.Systems;
 using Content.Server._Crescent.ShipShields;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Gravity;
+using Content.Server.Power.EntitySystems;
 using Content.Server.Salvage;
 using Content.Server.Station.Systems;
 using Content.Shared._NF.Shipyard.Components;
@@ -51,6 +52,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly GravityGeneratorSystem _gravityGenerators = default!;
     [Dependency] private readonly ShipShieldsSystem _shipShields = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetwork = default!;
+    [Dependency] private readonly ExtensionCableSystem _extensionCables = default!;
     [Dependency] private readonly SalvageSystem _salvage = default!;
     [Dependency] private readonly StationJobsSystem _stationJobs = default!;
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -9,6 +9,7 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
+using System.Linq;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
@@ -21,6 +22,7 @@ public abstract partial class SharedGunSystem
     protected virtual void InitializeBallistic()
     {
         SubscribeLocalEvent<BallisticAmmoProviderComponent, ComponentInit>(OnBallisticInit);
+        SubscribeLocalEvent<BallisticAmmoProviderComponent, ComponentStartup>(OnBallisticStartup);
         SubscribeLocalEvent<BallisticAmmoProviderComponent, MapInitEvent>(OnBallisticMapInit);
         SubscribeLocalEvent<BallisticAmmoProviderComponent, TakeAmmoEvent>(OnBallisticTakeAmmo);
         SubscribeLocalEvent<BallisticAmmoProviderComponent, CheckShootPrototypeEvent>(OnBallisticCheckProto); // Mono
@@ -260,13 +262,23 @@ public abstract partial class SharedGunSystem
     private void OnBallisticInit(EntityUid uid, BallisticAmmoProviderComponent component, ComponentInit args)
     {
         component.Container = Containers.EnsureContainer<Container>(uid, "ballistic-ammo");
+        SyncBallisticContainerState(component);
         // TODO: This is called twice though we need to support loading appearance data (and we need to call it on MapInit
         // to ensure it's correct).
         UpdateBallisticAppearance(uid, component);
     }
 
+    private void OnBallisticStartup(EntityUid uid, BallisticAmmoProviderComponent component, ComponentStartup args)
+    {
+        SyncBallisticContainerState(component);
+        UpdateBallisticAppearance(uid, component);
+        UpdateAmmoCount(uid);
+    }
+
     private void OnBallisticMapInit(EntityUid uid, BallisticAmmoProviderComponent component, MapInitEvent args)
     {
+        SyncBallisticContainerState(component);
+
         // TODO this should be part of the prototype, not set on map init.
         // Alternatively, just track spawned count, instead of unspawned count.
         if (component.Proto != null)
@@ -280,6 +292,20 @@ public abstract partial class SharedGunSystem
     protected int GetBallisticShots(BallisticAmmoProviderComponent component)
     {
         return component.Entities.Count + (component.InfiniteUnspawned ? 0 : component.UnspawnedCount); // Mono
+    }
+
+    private static void SyncBallisticContainerState(BallisticAmmoProviderComponent component)
+    {
+        if (component.Container == null)
+            return;
+
+        var contained = component.Container.ContainedEntities.ToList();
+
+        if (component.Entities.SequenceEqual(contained))
+            return;
+
+        component.Entities.Clear();
+        component.Entities.AddRange(contained);
     }
 
     private void OnBallisticTakeAmmo(EntityUid uid, BallisticAmmoProviderComponent component, TakeAmmoEvent args)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -350,7 +350,9 @@ public abstract partial class SharedGunSystem : EntitySystem
     protected void AttemptShoot(EntityUid user, EntityUid gunUid, GunComponent gun)
     {
         if (TryComp<AutoShootGunComponent>(gunUid, out var auto) && !auto.CanFire && auto.RemainingTime <= TimeSpan.FromSeconds(0)) // Frontier // Mono
+        {
             return; // Frontier
+        }
 
         if (gun.FireRateModified <= 0f ||
             !_actionBlockerSystem.CanAttack(user))
@@ -361,7 +363,9 @@ public abstract partial class SharedGunSystem : EntitySystem
         var toCoordinates = gun.ShootCoordinates;
 
         if (toCoordinates == null)
+        {
             return;
+        }
 
         var curTime = Timing.CurTime;
 
@@ -373,16 +377,22 @@ public abstract partial class SharedGunSystem : EntitySystem
         };
         RaiseLocalEvent(gunUid, ref prevention);
         if (prevention.Cancelled)
+        {
             return;
+        }
 
         RaiseLocalEvent(user, ref prevention);
         if (prevention.Cancelled)
+        {
             return;
+        }
 
         // Need to do this to play the clicking sound for empty automatic weapons
         // but not play anything for burst fire.
         if (gun.NextFire > curTime)
+        {
             return;
+        }
 
         var fireRate = TimeSpan.FromSeconds(1f / gun.FireRateModified);
 


### PR DESCRIPTION
About the PR
Fixes ship weapons not firing after a ship is stored and retrieved via the shipyard or persistence anchor.
Closes #15

Root cause: GunComponent.FireRateModified (and other *Modified fields) are not serialized — they are only populated by RefreshModifiers() on MapInitEvent. After a ship restore, MapInit does not re-fire for existing entities, leaving FireRateModified = 0. Every call to AttemptShoot hit the gun.FireRateModified <= 0f guard and returned immediately, silently discarding the shot.

Fix: ResyncGridFireControl now calls _gun.RefreshModifiers per gun after resetting stale runtime state, so all modified fields are recalculated before the gun is re-registered with its controlling server. Additional hardening:

FireControllableComponent and GunComponent runtime fields reset on resync (ControllingServer, NextFire, ShotCounter, burst state)
AutoShootGunComponent re-enabled on resync
ExtensionCableSystem.ResyncGridConnections added and called in both restore paths
BallisticAmmoProvider container state synced on ComponentStartup
Why / Balance
Weapons on retrieved/restored ships were non-functional until the gun entity was replaced. This restores expected behaviour with no balance change.

Media
N/A — code fix only.

Requirements
 I have read relevant guidelines/documentation to this PR found on our devwiki.
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Place a ship with turrets/weapons in the shipyard or dock it to a persistence anchor
Store/retrieve the ship
Engage a target — weapons should fire normally without needing to replace gun entities
Breaking changes
None.

Changelog

:cl:

fix: Ship weapons now fire correctly after being stored and retrieved via shipyard or persistence anchor
:cl: