### PR TITLE
Fix: Persist Newly Placed Anchors Immediately

### DIFF
--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -568,8 +568,11 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
     private void OnAnchorMapInit(Entity<PersistenceAnchorComponent> ent, ref MapInitEvent args)
     {
-        // Avoid mutating freshly spawned anchors during prototype validation.
-        TryRegisterAnchor(ent, ent.Comp, immediateSave: false);
+        // immediateSave: true so anchors placed mid-game (admin spawn, construction)
+        // get an AnchorId assigned and a snapshot written immediately.
+        // Prototype validation is still safe: TryRegisterAnchor returns early when
+        // the entity has no valid shuttle/station grid.
+        TryRegisterAnchor(ent, ent.Comp, immediateSave: true);
     }
 
     private void OnOwnerIdInserted(Entity<PersistenceAnchorComponent> ent, ref EntInsertedIntoContainerMessage args)
@@ -593,7 +596,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
             return;
         }
 
-        TryRegisterAnchor(ent, ent.Comp, immediateSave: false);
+        TryRegisterAnchor(ent, ent.Comp, immediateSave: true);
     }
 
     private void OnAnchorShutdown(Entity<PersistenceAnchorComponent> ent, ref ComponentShutdown args)


### PR DESCRIPTION
About the PR
Fixes persistence anchors placed during runtime (admin-spawned or constructed in-game) not being registered/saved unless manually forced.
OnAnchorMapInit and OnAnchorStateChanged now register with immediateSave: true, so a new anchor gets an AnchorId, is tracked, and writes an initial snapshot immediately.
This ensures autosave scheduling starts correctly for newly placed anchors.
Closes #38.

Why / Balance
This is a persistence reliability fix (no gameplay balance change).
It prevents data loss/confusion where anchors appeared valid but were never tracked until a manual admin save command was used.

Media
N/A (systems fix, no visual/content change required).

Requirements
 I have read relevant guidelines/documentation to this PR found on our devwiki.
 I have added media to this PR or it does not require an ingame showcase.
 I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
How to test
Start a round and place a persistence anchor by admin spawning it onto a valid station/shuttle grid.
Repeat by constructing one in-game.
Confirm both anchors are registered without using manual save command.
Move/change the anchored grid and wait for autosave interval (or inspect persistence output/log behavior) to verify periodic saves occur.
Restart and confirm restored state is present for those anchors.
Breaking changes
None.

Changelog
:cl:

fix: Persistence anchors placed during runtime now immediately register and save, allowing normal autosave/restore behavior without manual intervention