### PR TITLE
Fix Shipyard Mech and Vehicle State Restore

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Emp; // Monolith
 using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
@@ -21,6 +22,8 @@ using Content.Shared.Verbs;
 using Content.Shared.Wires;
 using Content.Server.Body.Systems;
 using Content.Shared.Tools.Systems;
+using Content.Server.Weapons.Ranged.Systems;
+using Content.Shared.Weapons.Ranged.Components;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
@@ -48,6 +51,7 @@ public sealed partial class MechSystem : SharedMechSystem
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly SharedToolSystem _toolSystem = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+    [Dependency] private readonly GunSystem _gun = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -135,6 +139,7 @@ public sealed partial class MechSystem : SharedMechSystem
         component.Energy = battery.CurrentCharge;
         component.MaxEnergy = battery.MaxCharge;
         component.CriticalPowerState = battery.CurrentCharge / battery.MaxCharge <= 0.05f; // Mono
+        ReconcileIntegrity(uid, component);
         Dirty(uid, component);
 
         _movementSpeed.RefreshMovementSpeedModifiers(uid); // Mono
@@ -155,19 +160,87 @@ public sealed partial class MechSystem : SharedMechSystem
     private void OnMapInit(EntityUid uid, MechComponent component, MapInitEvent args)
     {
         var xform = Transform(uid);
-        // TODO: this should use containerfill?
-        foreach (var equipment in component.StartingEquipment)
+        // Avoid duplicating starter gear on deserialized mechs.
+        if (component.EquipmentContainer.ContainedEntities.Count == 0)
         {
-            var ent = Spawn(equipment, xform.Coordinates);
-            InsertEquipment(uid, ent, component);
+            // TODO: this should use containerfill?
+            foreach (var equipment in component.StartingEquipment)
+            {
+                var ent = Spawn(equipment, xform.Coordinates);
+                InsertEquipment(uid, ent, component);
+            }
         }
 
-        // TODO: this should just be damage and battery
-        component.Integrity = component.MaxIntegrity;
-        component.Energy = component.MaxEnergy;
+        ReconcileMechState(uid, component);
 
         _actionBlocker.UpdateCanMove(uid);
+        _movementSpeed.RefreshMovementSpeedModifiers(uid);
         Dirty(uid, component);
+    }
+
+    private void ReconcileMechState(EntityUid uid, MechComponent component)
+    {
+        ReconcileIntegrity(uid, component);
+
+        if (component.BatterySlot.ContainedEntity is { } batteryUid && TryComp<BatteryComponent>(batteryUid, out var battery))
+        {
+            component.Energy = battery.CurrentCharge;
+            component.MaxEnergy = battery.MaxCharge;
+            component.CriticalPowerState = battery.CurrentCharge / battery.MaxCharge <= 0.05f;
+        }
+        else if (component.Energy == 0 && component.MaxEnergy > 0)
+        {
+            component.Energy = component.MaxEnergy;
+        }
+    }
+
+    private void ReconcileIntegrity(EntityUid uid, MechComponent component)
+    {
+        if (TryComp<DamageableComponent>(uid, out var damageable))
+        {
+            var integrity = component.MaxIntegrity - damageable.TotalDamage;
+            component.Integrity = integrity < 0 ? 0 : integrity;
+            return;
+        }
+
+        if (component.Integrity == 0)
+            component.Integrity = component.MaxIntegrity;
+    }
+
+    public void ResyncGridMechs(EntityUid gridUid)
+    {
+        var mechQuery = EntityQueryEnumerator<MechComponent, TransformComponent>();
+        while (mechQuery.MoveNext(out var mechUid, out var mechComp, out var mechXform))
+        {
+            if (mechXform.GridUid != gridUid)
+                continue;
+
+            ReconcileMechState(mechUid, mechComp);
+
+            // Re-link EquipmentOwner — not serialized, so it is null after a load.
+            // Also refresh gun modifiers — FireRateModified is only set via MapInitEvent,
+            // which doesn't fire on midround grid loads, leaving FireRateModified = 0
+            // and silently blocking all ranged fire.
+            foreach (var equipUid in mechComp.EquipmentContainer.ContainedEntities)
+            {
+                if (TryComp<MechEquipmentComponent>(equipUid, out var equipComp))
+                    equipComp.EquipmentOwner = mechUid;
+
+                if (TryComp<GunComponent>(equipUid, out var gunComp))
+                    _gun.RefreshModifiers((equipUid, gunComp));
+            }
+
+            // CurrentSelectedEquipment is also not serialized; if there is equipment
+            // installed, auto-select the first piece so ranged weapons fire immediately.
+            if (mechComp.CurrentSelectedEquipment == null &&
+                mechComp.EquipmentContainer.ContainedEntities.Count > 0)
+            {
+                CycleEquipment(mechUid, mechComp);
+            }
+
+            _movementSpeed.RefreshMovementSpeedModifiers(mechUid);
+            Dirty(mechUid, mechComp);
+        }
     }
 
     private void OnRemoveEquipmentMessage(EntityUid uid, MechComponent component, MechEquipmentRemoveMessage args)

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -38,6 +38,7 @@ using Content.Server._NF.Station.Components;
 using Content.Server.Station.Components;
 using System.Text.RegularExpressions;
 using Content.Server._Mono.Shipyard;
+using Content.Server.Mech.Systems;
 using Content.Server.Shuttles.Systems;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
@@ -83,6 +84,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly FireControlSystem _fireControl = default!;
+    [Dependency] private readonly MechSystem _mech = default!;
 
     private static readonly ProtoId<TagPrototype> CrewedShuttleTag = "CrewedShuttle";
     private static readonly Regex DeedRegex = new(@"\s*\([^()]*\)");
@@ -642,11 +644,13 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         {
             Category = FileCategory.Grid,
             MissingEntityBehaviour = MissingEntityBehaviour.Ignore,
-            EntityExceptionBehaviour = EntityExceptionBehaviour.IgnoreEntityAndChildren,
+            EntityExceptionBehaviour = EntityExceptionBehaviour.IgnoreEntity,
             ErrorOnOrphan = false,
             LogAutoInclude = null,
         };
 
+        // Save from the shuttle grid root to avoid selecting transient runtime entities
+        // (e.g. actions/audio) as serialization roots.
         if (!_mapLoader.TrySaveGrid(shuttleUid, snapshotPath, saveOptions))
         {
             ConsolePopup(player, Loc.GetString("shipyard-console-storage-save-failed"));
@@ -797,6 +801,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _shipShields.ResyncGridShields(shuttleUid);
         _salvage.ResyncGridExpeditionConsoles(shuttleUid);
         _fireControl.ResyncGridFireControl(shuttleUid);
+        _mech.ResyncGridMechs(shuttleUid);
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;
         var deedID = EnsureComp<ShuttleDeedComponent>(targetId);

--- a/Content.Shared/Vehicle/SharedVehicleSystem.cs
+++ b/Content.Shared/Vehicle/SharedVehicleSystem.cs
@@ -40,6 +40,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualItemSystem = default!;
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedJointSystem _joints = default!;
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
     [Dependency] private readonly SharedMoverController _mover = default!;
@@ -104,6 +105,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
             strap.BuckleOffset = Vector2.Zero;
         }
 
+        ReconcileKeyState(uid, component);
         _modifier.RefreshMovementSpeedModifiers(uid);
     }
 
@@ -228,9 +230,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         if (_netManager.IsServer)
             _popupSystem.PopupEntity(msg, uid, args.OldParent, PopupType.Medium);
 
-        // Audiovisual feedback
-        _ambientSound.SetAmbience(uid, true);
-        _modifier.RefreshMovementSpeedModifiers(uid);
+        ReconcileKeyState(uid, component);
     }
 
     /// <summary>
@@ -238,13 +238,34 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     /// </summary>
     private void OnEntRemoved(EntityUid uid, VehicleComponent component, EntRemovedFromContainerMessage args)
     {
-        if (args.Container.ID != KeySlot || !RemComp<InVehicleComponent>(args.Entity))
+        if (args.Container.ID != KeySlot)
             return;
 
-        // Disable vehicle
-        component.HasKey = false;
-        _ambientSound.SetAmbience(uid, false);
+        RemComp<InVehicleComponent>(args.Entity);
+        ReconcileKeyState(uid, component);
+    }
+
+    private void ReconcileKeyState(EntityUid uid, VehicleComponent component)
+    {
+        var hasKey = false;
+
+        if (_container.TryGetContainer(uid, KeySlot, out var keySlot))
+        {
+            foreach (var ent in keySlot.ContainedEntities)
+            {
+                if (!_tagSystem.HasTag(ent, "VehicleKey"))
+                    continue;
+
+                var inVehicle = EnsureComp<InVehicleComponent>(ent);
+                inVehicle.Vehicle = component;
+                hasKey = true;
+            }
+        }
+
+        component.HasKey = hasKey;
+        _ambientSound.SetAmbience(uid, hasKey);
         _modifier.RefreshMovementSpeedModifiers(uid);
+        Dirty(uid, component);
     }
 
     private void OnRefreshMovementSpeedModifiers(EntityUid uid, VehicleComponent component, RefreshMovementSpeedModifiersEvent args)

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BaseMech
-  save: false
+  save: true
   abstract: true
   components:
   - type: MobMover

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BaseVehicle
-  save: false
+  save: true
   abstract: true
   components:
   - type: AmbientSound


### PR DESCRIPTION
## About the PR
Closes #11

Fixes shipyard persistence and restore issues for vehicles and mechs.

This changes ship saving to use grid-root serialization instead of a generic entity set, which avoids transient runtime entities being selected as serialization roots. On retrieve, vehicles and mechs now resync the runtime-only state that is not preserved by save/load.

For vehicles, this restores key linkage, engine ambience, and key ejection behavior.

For mechs, this restores energy and integrity values, avoids duplicating starting equipment on load, re-links installed equipment back to the owning mech, restores a selected weapon after load, and refreshes gun modifiers so ranged mech weapons can fire after a midround retrieve.

## Why / Balance
This is a bugfix for broken shuttle persistence behavior and does not intentionally change balance.

Without this, stored ships could fail to save, vehicles could lose key behavior after retrieval, and mechs could come back with broken UI state or unusable ranged weapons.

## Media
No media required. This is a persistence/runtime state fix.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Spawn or obtain a mech with melee and ranged equipment, plus a vehicle such as an ATV or hoverbike.
2. Store the ship through the shipyard console.
3. Retrieve the ship midround through the shipyard console.
4. Verify the vehicle key is still linked correctly, can be ejected, and engine ambience works.
5. Enter the mech and verify energy and integrity display correctly.
6. Verify starting mech equipment is not duplicated after retrieval.
7. Cycle mech equipment and confirm melee and ranged weapons both work after retrieval.
8. Specifically verify weapons such as the LBX AC 10, SRM-8 Light Missile Rack, and P-X Tesla Cannon can fire after restore.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed shipyard shuttle retrieval failing to fully restore mech and vehicle runtime state.
- fix: Fixed vehicles losing key behavior and ambience after shipyard retrieval.
- fix: Fixed mechs showing incorrect integrity/energy and losing ranged weapon functionality after shipyard retrieval.