### PR TITLE
Fix Dock Airlock and Gaslock State Restore on Ship Retrieval and Pers…

### DIFF
--- a/Content.Server/Shuttles/Systems/DockingSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.cs
@@ -1,7 +1,15 @@
+using Content.Server.DeviceLinking.Systems;
 using Content.Server.Doors.Systems;
+using Content.Server._NF.Atmos.Components;
+using Content.Server.NodeContainer;
 using Content.Server.NPC.Pathfinding;
+using Content.Server.NodeContainer.EntitySystems;
+using Content.Server.NodeContainer.Nodes;
+using Content.Server.Power.Nodes;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
+using Content.Shared._NF.Atmos.Visuals;
+using Content.Shared._NF.Power.Components;
 using Content.Shared.Doors;
 using Content.Shared.Doors.Components;
 using Content.Shared.Popups;
@@ -14,6 +22,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics.Joints;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Utility;
+using Robust.Server.GameObjects;
 
 namespace Content.Server.Shuttles.Systems
 {
@@ -21,8 +30,12 @@ namespace Content.Server.Shuttles.Systems
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+        [Dependency] private readonly AppearanceSystem _appearance = default!;
+        [Dependency] private readonly DeviceLinkSystem _deviceLink = default!;
         [Dependency] private readonly DoorSystem _doorSystem = default!;
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
+        [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
+        [Dependency] private readonly NodeGroupSystem _nodeGroup = default!;
         [Dependency] private readonly PathfindingSystem _pathfinding = default!;
         [Dependency] private readonly ShuttleConsoleSystem _console = default!;
         [Dependency] private readonly SharedJointSystem _jointSystem = default!;
@@ -95,6 +108,73 @@ namespace Content.Server.Shuttles.Systems
                 _doorSystem.TryClose(entity);
                 _doorSystem.SetBoltsDown((entity.Owner, entity.Comp2), enabled);
             }
+        }
+
+        public void ResyncGridDockAirlocks(EntityUid gridUid)
+        {
+            _dockingSet.Clear();
+            _lookup.GetChildEntities(gridUid, _dockingSet);
+
+            foreach (var dock in _dockingSet)
+            {
+                var uid = dock.Owner;
+                var docking = dock.Comp;
+
+                var validDock = docking.DockedWith is { } otherUid &&
+                                Exists(otherUid) &&
+                                TryComp<DockingComponent>(otherUid, out var otherDock) &&
+                                otherDock.DockedWith == uid;
+
+                if (validDock)
+                    continue;
+
+                if (docking.DockedWith != null || docking.DockJoint != null || docking.DockJointId != null)
+                {
+                    docking.DockedWith = null;
+                    docking.DockJoint = null;
+                    docking.DockJointId = null;
+                    Dirty(uid, docking);
+                }
+
+                if (TryComp<DockingSignalControlComponent>(uid, out var signalControl))
+                    _deviceLink.SendSignal(uid, signalControl.DockStatusSignalPort, signal: false);
+
+                if (TryComp<DockablePipeComponent>(uid, out var dockablePipe) &&
+                    TryComp<NodeContainerComponent>(uid, out var nodeContainer) &&
+                    !string.IsNullOrEmpty(dockablePipe.DockNodeName) &&
+                    _nodeContainer.TryGetNode(nodeContainer, dockablePipe.DockNodeName, out DockablePipeNode? dockablePipeNode))
+                {
+                    _nodeGroup.QueueNodeRemove(dockablePipeNode);
+                    dockablePipeNode.Air.Clear();
+                    _appearance.SetData(uid, DockablePipeVisuals.Docked, false);
+                }
+
+                if (TryComp<GaslockPowerBridgeComponent>(uid, out var gaslockBridge) &&
+                    TryComp<NodeContainerComponent>(uid, out var bridgeNodes))
+                {
+                    QueueDockBridgeNodeRemove(bridgeNodes, gaslockBridge.HvDockNode);
+                    QueueDockBridgeNodeRemove(bridgeNodes, gaslockBridge.MvDockNode);
+                    QueueDockBridgeNodeRemove(bridgeNodes, gaslockBridge.LvDockNode);
+                }
+
+                if (TryComp<DoorBoltComponent>(uid, out var bolts) && bolts.BoltsDown)
+                    _doorSystem.SetBoltsDown((uid, bolts), false);
+
+                if (TryComp<DoorComponent>(uid, out var door))
+                {
+                    _doorSystem.TryClose(uid, door);
+                    door.ChangeAirtight = true;
+                    Dirty(uid, door);
+                }
+            }
+        }
+
+        private void QueueDockBridgeNodeRemove(NodeContainerComponent nodeContainer, string nodeName)
+        {
+            if (!nodeContainer.Nodes.TryGetValue(nodeName, out var node) || node is not CableDeviceNode cableNode)
+                return;
+
+            _nodeGroup.QueueNodeRemove(cableNode);
         }
 
         private void OnAutoClose(EntityUid uid, DockingComponent component, BeforeDoorAutoCloseEvent args)

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.Gravity;
 using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
 using Content.Server.Power.EntitySystems;
+using Content.Server.Mech.Systems;
 using Content.Server.Salvage;
 using Content.Server.Shuttles.Components;
 using Content.Server._Mono.FireControl;
@@ -81,6 +82,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     [Dependency] private readonly ExtensionCableSystem _extensionCables = default!;
     [Dependency] private readonly SalvageSystem _salvage = default!;
     [Dependency] private readonly FireControlSystem _fireControl = default!;
+    [Dependency] private readonly MechSystem _mech = default!;
 
     private readonly Dictionary<EntityUid, string> _gridToAnchor = new();
     private readonly Dictionary<string, EntityUid> _anchorToGrid = new();
@@ -384,6 +386,8 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
             _shipShields.ResyncGridShields(grid);
             _salvage.ResyncGridExpeditionConsoles(grid);
             _fireControl.ResyncGridFireControl(grid);
+            _dockingSystem.ResyncGridDockAirlocks(grid);
+            _mech.ResyncGridMechs(grid);
 
             SaveSnapshot(anchor, component, immediate: true);
             _pendingRestoreHealAnchors.Remove(anchorId);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -801,6 +801,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _shipShields.ResyncGridShields(shuttleUid);
         _salvage.ResyncGridExpeditionConsoles(shuttleUid);
         _fireControl.ResyncGridFireControl(shuttleUid);
+        _docking.ResyncGridDockAirlocks(shuttleUid);
         _mech.ResyncGridMechs(shuttleUid);
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;


### PR DESCRIPTION
## About the PR
Closes #22
Fixes dockable airlocks and gaslocks being left in a bolted-open / docked state after a ship is retrieved from the shipyard or restored by the persistence anchor system on server restart.

When a ship is saved and reloaded, its `DockingComponent` entries retain their last-docked state (open door, bolts down, pipe node connected, gaslock bridge active, dock signal high). The normal `UndockEvent` handlers that clean all of this up never fire during snapshot restore, leaving the ship in a broken state.

**Changes:**
- Added `DockingSystem.ResyncGridDockAirlocks(EntityUid gridUid)` — iterates all `DockingComponent` entities on the grid, detects stale dock links (partner doesn't exist), and for each:
  - Clears `DockedWith` / `DockJoint` / `DockJointId` and dirties
  - Sends `DockStatus = false` via `DeviceLinkSystem` (`DockingSignalControlComponent`)
  - Removes the `DockablePipeNode`, clears its gas mix, sets `DockablePipeVisuals.Docked = false`
  - Removes HV/MV/LV dock cable nodes from `GaslockPowerBridgeComponent`
  - Calls `SetBoltsDown(false)` + `TryClose` + `ChangeAirtight = true` for any `DoorComponent`
- Wired `ResyncGridDockAirlocks` into both the shipyard retrieve path (`ShipyardSystem.Consoles.cs`) and the persistence anchor heal path (`PersistenceAnchorSystem.HealRestoredSnapshots`), alongside the existing resync calls.
- Also wired `MechSystem.ResyncGridMechs` into `PersistenceAnchorSystem.HealRestoredSnapshots` (previously only called on shipyard retrieve, not on server-restart restore).

## Why / Balance
Bug fix only. Dockable airlocks stuck bolted-open blocked crew movement and made the ship inoperable after retrieval. Gaslocks left in the docked visual/pipe state could cause incorrect gas routing.

## Media
N/A — infrastructure/bug fix, no visual changes to showcase.

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Load a ship that has dockable airlocks or gaslocks.
2. While docked to a station, sell/deregister the ship so it is saved to a snapshot.
3. Retrieve the ship mid-round via the shipyard console.
4. Verify: dock airlocks are closed and unbolted, gaslock shows undocked visual with no pipe/power bridge connection.
5. Repeat by restarting the server (without a round restart) and confirming the same on restore.

## Breaking changes
None. `DockingSystem.ResyncGridDockAirlocks` is a new public method; no existing APIs changed.

**Changelog**
:cl:
- fix: Fixed dockable airlocks being bolted open after ship retrieval from the shipyard or server restart.
- fix: Fixed gaslocks showing docked visuals, active pipe connections, and live power bridge nodes after ship retrieval or server restart.
- fix: Fixed mech ranged equipment state (fire rate) not being restored when a ship is reloaded via the persistence anchor system.