### PR TITLE
Fix Stale Material Insertion Visuals After Ship Restore

### DIFF
--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Construction;
 using Content.Shared.Database;
 using JetBrains.Annotations;
+using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
@@ -31,6 +32,7 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StackSystem _stackSystem = default!;
+    [Dependency] private new readonly AppearanceSystem _appearance = default!;
 
     public override void Initialize()
     {
@@ -57,6 +59,25 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
             return;
 
         DropAll(ent);
+    }
+
+    // Mono
+    /// <summary>
+    /// Clears any stale insertion animation state from all material storage entities on a grid.
+    /// Called after a ship is retrieved or restored from a snapshot, since MapInitEvent does not
+    /// fire on midround loads and the saved appearance data may have Inserting = true.
+    /// </summary>
+    public void ResyncGridMaterialStorage(EntityUid gridUid)
+    {
+        var query = EntityQueryEnumerator<MaterialStorageComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            RemComp<InsertingMaterialStorageComponent>(uid);
+            _appearance.SetData(uid, MaterialStorageVisuals.Inserting, false);
+        }
     }
 
     // Mono

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -10,6 +10,7 @@ using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Mech.Systems;
+using Content.Server.Materials;
 using Content.Server.Salvage;
 using Content.Server.Shuttles.Components;
 using Content.Server._Mono.FireControl;
@@ -83,6 +84,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     [Dependency] private readonly SalvageSystem _salvage = default!;
     [Dependency] private readonly FireControlSystem _fireControl = default!;
     [Dependency] private readonly MechSystem _mech = default!;
+    [Dependency] private readonly MaterialStorageSystem _materialStorage = default!;
 
     private readonly Dictionary<EntityUid, string> _gridToAnchor = new();
     private readonly Dictionary<string, EntityUid> _anchorToGrid = new();
@@ -388,6 +390,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
             _fireControl.ResyncGridFireControl(grid);
             _dockingSystem.ResyncGridDockAirlocks(grid);
             _mech.ResyncGridMechs(grid);
+            _materialStorage.ResyncGridMaterialStorage(grid);
 
             SaveSnapshot(anchor, component, immediate: true);
             _pendingRestoreHealAnchors.Remove(anchorId);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -38,6 +38,7 @@ using Content.Server._NF.Station.Components;
 using Content.Server.Station.Components;
 using System.Text.RegularExpressions;
 using Content.Server._Mono.Shipyard;
+using Content.Server.Materials;
 using Content.Server.Mech.Systems;
 using Content.Server.Shuttles.Systems;
 using Content.Shared.UserInterface;
@@ -84,6 +85,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly FireControlSystem _fireControl = default!;
+    [Dependency] private readonly MaterialStorageSystem _materialStorage = default!;
     [Dependency] private readonly MechSystem _mech = default!;
 
     private static readonly ProtoId<TagPrototype> CrewedShuttleTag = "CrewedShuttle";
@@ -803,6 +805,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _fireControl.ResyncGridFireControl(shuttleUid);
         _docking.ResyncGridDockAirlocks(shuttleUid);
         _mech.ResyncGridMechs(shuttleUid);
+        _materialStorage.ResyncGridMaterialStorage(shuttleUid);
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;
         var deedID = EnsureComp<ShuttleDeedComponent>(targetId);


### PR DESCRIPTION
## About the PR
Closes #20
Fixes machines with material storage (including lathes) getting stuck showing the material insertion animation after ship retrieval or persistence-anchor restore.

On snapshot restore, saved appearance state could keep `MaterialStorageVisuals.Inserting = true`, and midround loads do not run the normal map-init reset path. This left insertion visuals stuck until the machine was interacted with again.

This PR adds a grid resync pass for material storage and runs it in both restore flows:
- Shipyard retrieve path
- Persistence anchor heal/restore path

## Why / Balance
Pure bugfix with no balance impact. It restores expected machine visual behavior after loading persisted ships.

## Media
N/A (small backend/visual-state bugfix).

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Use a ship that has a lathe or any machine using material storage.
2. Ensure the ship is saved and then restored (either shipyard retrieve or persistence anchor restore).
3. Observe machine visuals immediately after restore.
4. Verify insertion animation is not stuck on.
5. Insert material normally and verify insertion animation still plays/ends correctly.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed lathes and other material-storage machines showing stuck material insertion animations after ship retrieval or persistence-anchor restore.