### PR TITLE
Add Breathable Atmosphere Toggle for Expedition Planets

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -327,6 +327,7 @@ public sealed partial class SalvageSystem
             this,
             _transform,
             _mapSystem,
+            _cfgManager,
             station,
             coordinatesDisk,
             missionParams,

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -31,6 +31,7 @@ using Content.Shared.Shuttles.Components;
 using Content.Shared.Storage;
 using Content.Server.Weather;
 using Content.Shared.Weather;
+using Content.Shared._NF.CCVar;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
@@ -38,6 +39,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Configuration;
 using Content.Shared._Crescent.SpaceBiomes;
 
 namespace Content.Server.Salvage;
@@ -58,6 +60,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
     private readonly SalvageSystem _salvage;
     private readonly SharedTransformSystem _xforms;
     private readonly SharedMapSystem _map;
+    private readonly IConfigurationManager _cfg;
 
     public readonly EntityUid Station;
     public readonly EntityUid? CoordinatesDisk;
@@ -92,6 +95,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         SalvageSystem salvage,
         SharedTransformSystem xform,
         SharedMapSystem map,
+        IConfigurationManager cfg,
         EntityUid station,
         EntityUid? coordinatesDisk,
         SalvageMissionParams missionParams,
@@ -111,6 +115,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         _salvage = salvage;
         _xforms = xform;
         _map = map;
+        _cfg = cfg;
         Station = station;
         CoordinatesDisk = coordinatesDisk;
         _missionParams = missionParams;
@@ -194,14 +199,29 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
 
             // Atmos
             var air = _prototypeManager.Index<SalvageAirMod>(mission.Air);
-            // copy into a new array since the yml deserialization discards the fixed length
+            var breathableAtmos = _cfg.GetCVar(NFCCVars.SalvageExpeditionBreathableAtmos);
             var moles = new float[Atmospherics.AdjustedNumberOfGases];
-            air.Gases.CopyTo(moles, 0);
-            var atmos = _entManager.EnsureComponent<MapAtmosphereComponent>(mapUid);
-            _entManager.System<AtmosphereSystem>().SetMapSpace(mapUid, air.Space, atmos);
-            _entManager.System<AtmosphereSystem>().SetMapGasMixture(mapUid, new GasMixture(moles, mission.Temperature), atmos);
+            var setSpace = air.Space;
+            var setTemperature = mission.Temperature;
 
-            if (!air.Space)
+            if (breathableAtmos)
+            {
+                setSpace = false;
+                setTemperature = Atmospherics.T20C;
+                moles[(int) Gas.Oxygen] = Atmospherics.OxygenMolesStandard;
+                moles[(int) Gas.Nitrogen] = Atmospherics.NitrogenMolesStandard;
+            }
+            else
+            {
+                // Copy into a new array since yml deserialization discards fixed length arrays.
+                air.Gases.CopyTo(moles, 0);
+            }
+
+            var atmos = _entManager.EnsureComponent<MapAtmosphereComponent>(mapUid);
+            _entManager.System<AtmosphereSystem>().SetMapSpace(mapUid, setSpace, atmos);
+            _entManager.System<AtmosphereSystem>().SetMapGasMixture(mapUid, new GasMixture(moles, setTemperature), atmos);
+
+            if (!setSpace)
             {
                 var weather = _entManager.EnsureComponent<WeatherComponent>(mapUid);
                 _entManager.System<WeatherSystem>().SetWeather(mapId, _prototypeManager.Index<WeatherPrototype>(missionWeather.WeatherPrototype), null);

--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -142,6 +142,12 @@ public sealed class NFCCVars
     public static readonly CVarDef<bool> SalvageExpeditionRewardsEnabled =
         CVarDef.Create("nf14.salvage.expedition_rewards_enabled", false, CVar.REPLICATED);
 
+    /// <summary>
+    /// Whether expedition planet maps should always use a breathable atmosphere.
+    /// </summary>
+    public static readonly CVarDef<bool> SalvageExpeditionBreathableAtmos =
+        CVarDef.Create("nf14.salvage.expedition_breathable_atmos", true, CVar.SERVERONLY);
+
     /*
      * Smuggling
      */


### PR DESCRIPTION
## About the PR

Adds a toggleable breathable atmosphere override for salvage expedition planets/maps, with the default set to enabled.

- Added new server cvar: `nf14.salvage.expedition_breathable_atmos` (default: `true`)
- Wired expedition mission spawning to read the cvar
- When enabled, expedition maps are forced to:
  - non-space atmosphere
  - standard breathable O2/N2 mix
  - standard room temperature
- When disabled, expedition maps keep their mission-defined atmosphere behavior

Closes #29

## Why / Balance

This improves expedition accessibility and reduces mandatory EVA pressure by default, while preserving configurability for servers that want hostile atmospherics. Admins can disable the override to restore mission-specific atmosphere mixes.

## Media

N/A (systems/config behavior change only)

## Requirements

- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

1. Ensure cvar is enabled (default):
   - `nf14.salvage.expedition_breathable_atmos true`
2. Start a salvage expedition and travel to the expedition map.
3. Verify the map has breathable air and normal room-temperature atmosphere.
4. Disable the cvar:
   - `nf14.salvage.expedition_breathable_atmos false`
5. Start another expedition and verify mission-defined atmosphere behavior is used again.
6. Regression check:
   - Run `SpawnAndDeleteAllEntitiesInTheSameSpot` integration test and confirm pass.

## Breaking changes

None.

## Changelog
:cl:
- tweak: Added a server toggle to force breathable atmosphere on salvage expedition planets (enabled by default).