### PR TITLE
Dev

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "RobustToolbox"]
 	path = RobustToolbox
-	url = https://github.com/space-wizards/RobustToolbox.git
+	url = https://github.com/6th-Maroon-Division/RobustToolbox.git
 	branch = master

--- a/Content.Client/IconSmoothing/IconSmoothSystem.cs
+++ b/Content.Client/IconSmoothing/IconSmoothSystem.cs
@@ -42,6 +42,7 @@ namespace Content.Client.IconSmoothing
             SubscribeLocalEvent<IconSmoothComponent, AnchorStateChangedEvent>(OnAnchorChanged);
             SubscribeLocalEvent<IconSmoothComponent, ComponentShutdown>(OnShutdown);
             SubscribeLocalEvent<IconSmoothComponent, ComponentStartup>(OnStartup);
+            SubscribeLocalEvent<IconSmoothComponent, EntParentChangedMessage>(OnParentChanged);
         }
 
         private void OnStartup(EntityUid uid, IconSmoothComponent component, ComponentStartup args)
@@ -211,6 +212,11 @@ namespace Content.Client.IconSmoothing
                 _anchorChangedEntities.Enqueue(uid);
         }
 
+        private void OnParentChanged(EntityUid uid, IconSmoothComponent component, ref EntParentChangedMessage args)
+        {
+            _anchorChangedEntities.Enqueue(uid);
+        }
+
         private void CalculateNewSprite(EntityUid uid,
             EntityQuery<SpriteComponent> spriteQuery,
             EntityQuery<IconSmoothComponent> smoothQuery,
@@ -278,7 +284,7 @@ namespace Content.Client.IconSmoothing
                 }
                 else
                 {
-                    Log.Error($"Failed to calculate IconSmoothComponent sprite in {uid} because grid {xform.GridUid} was missing.");
+                    _dirtyEntities.Enqueue(uid);
                     return;
                 }
             }

--- a/Content.IntegrationTests/Tests/Shuttle/PersistenceRestoredWallVisualsTest.cs
+++ b/Content.IntegrationTests/Tests/Shuttle/PersistenceRestoredWallVisualsTest.cs
@@ -1,0 +1,78 @@
+using Robust.Client.GameObjects;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+
+namespace Content.IntegrationTests.Tests.Shuttle;
+
+[TestFixture]
+public sealed class PersistenceRestoredWallVisualsTest
+{
+    [Test]
+    public async Task RestoredWallsHaveNonBlankClientSprite()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var server = pair.Server;
+        var client = pair.Client;
+
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var serverEntManager = server.ResolveDependency<IEntityManager>();
+        var clientEntManager = client.ResolveDependency<IEntityManager>();
+        var mapLoader = serverEntManager.System<MapLoaderSystem>();
+        var mapSystem = serverEntManager.System<SharedMapSystem>();
+
+        var savePath = new ResPath("/restored-wall-visuals-test.yml");
+        EntityUid restoredWall = default;
+
+        await server.WaitAssertion(() =>
+        {
+            mapSystem.CreateMap(out var sourceMap);
+            var sourceGrid = mapManager.CreateGridEntity(sourceMap);
+
+            mapSystem.SetTile(sourceGrid, Vector2i.Zero, new Tile(typeId: 1, flags: 1, variant: 255));
+            mapSystem.SetTile(sourceGrid, new Vector2i(1, 0), new Tile(typeId: 1, flags: 1, variant: 255));
+
+            serverEntManager.SpawnEntity("WallReinforced", new EntityCoordinates(sourceGrid.Owner, 0.5f, 0.5f));
+            serverEntManager.SpawnEntity("WallReinforced", new EntityCoordinates(sourceGrid.Owner, 1.5f, 0.5f));
+
+            Assert.That(mapLoader.TrySaveGrid(sourceGrid.Owner, savePath), Is.True);
+            mapSystem.DeleteMap(sourceMap);
+
+            mapSystem.CreateMap(out var restoredMap);
+            Assert.That(mapLoader.TryLoadGrid(restoredMap, savePath, out var restoredGrid), Is.True);
+            Assert.That(restoredGrid, Is.Not.Null);
+
+            var wallQuery = serverEntManager.EntityQueryEnumerator<MetaDataComponent, TransformComponent>();
+            while (wallQuery.MoveNext(out var uid, out var meta, out var xform))
+            {
+                if (xform.GridUid != restoredGrid!.Value.Owner)
+                    continue;
+
+                if (meta.EntityPrototype?.ID != "WallReinforced")
+                    continue;
+
+                restoredWall = uid;
+                break;
+            }
+
+            Assert.That(restoredWall, Is.Not.EqualTo(EntityUid.Invalid));
+        });
+
+        await pair.RunTicksSync(10);
+
+        await client.WaitAssertion(() =>
+        {
+            var net = serverEntManager.GetNetEntity(restoredWall);
+            var clientWall = clientEntManager.GetEntity(net);
+
+            Assert.That(clientEntManager.TryGetComponent(clientWall, out SpriteComponent sprite), Is.True);
+            Assert.That(sprite!.TryGetLayer(0, out var layer), Is.True);
+            Assert.That(layer!.Blank, Is.False,
+                "Restored wall sprite is blank on client after save/load.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Atmos/Piping/Unary/Components/GasCanisterComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasCanisterComponent.cs
@@ -63,6 +63,13 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField("accessDeniedSound")]
         public SoundSpecifier AccessDeniedSound = new SoundPathSpecifier("/Audio/Machines/custom_deny.ogg");
 
+        /// <summary>
+        /// Whether canister interaction handlers should open canister UI on click/hand interact.
+        /// Composite machines can disable this and rely on their own ActivatableUI.
+        /// </summary>
+        [DataField("uiInteract")]
+        public bool UiInteract = true;
+
         #region GuidebookData
 
         [GuidebookData]

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -209,6 +209,9 @@ public sealed class GasCanisterSystem : EntitySystem
 
     private void OnCanisterActivate(EntityUid uid, GasCanisterComponent component, ActivateInWorldEvent args)
     {
+        if (!component.UiInteract)
+            return;
+
         if (!args.Complex)
             return;
 
@@ -229,6 +232,9 @@ public sealed class GasCanisterSystem : EntitySystem
 
     private void OnCanisterInteractHand(EntityUid uid, GasCanisterComponent component, InteractHandEvent args)
     {
+        if (!component.UiInteract)
+            return;
+
         if (!TryComp<ActorComponent>(args.User, out var actor))
             return;
 

--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Storage.Components; // Frontier
 using Content.Server.Cargo.Systems; // Frontier
 using Content.Server.Power.Components;
 using Content.Server.Stack;
+using Content.Shared.Materials.OreSilo;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Construction;
 using Content.Shared.Database;
@@ -32,6 +33,7 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StackSystem _stackSystem = default!;
+    [Dependency] private readonly SharedOreSiloSystem _oreSilo = default!;
     [Dependency] private new readonly AppearanceSystem _appearance = default!;
 
     public override void Initialize()
@@ -78,6 +80,19 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
             RemComp<InsertingMaterialStorageComponent>(uid);
             _appearance.SetData(uid, MaterialStorageVisuals.Inserting, false);
         }
+
+        // MapInit does not fire for midround snapshot loads; reset magnet scan timers
+        // so lathes/silos with material magnets resume pulling immediately.
+        var magnetQuery = EntityQueryEnumerator<MaterialStorageMagnetPickupComponent, TransformComponent>();
+        while (magnetQuery.MoveNext(out _, out var magnet, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            magnet.NextScan = TimeSpan.Zero;
+        }
+
+        _oreSilo.SanitizeGridOreSiloLinks(gridUid);
     }
 
     // Mono

--- a/Content.Server/Shuttles/Components/PersistenceAnchorComponent.cs
+++ b/Content.Server/Shuttles/Components/PersistenceAnchorComponent.cs
@@ -8,6 +8,7 @@ public sealed partial class PersistenceAnchorComponent : Component
 {
     public const string OwnerIdCardSlotId = "PersistenceAnchor-ownerId";
 
+    [DataField("anchorId")]
     [ViewVariables(VVAccess.ReadWrite)]
     public string? AnchorId { get; set; }
 

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -299,9 +299,19 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
                 continue;
             }
 
-            _pendingRestoredGridAnchors[loadedGrid.Value.Owner] = anchorId;
+            var loadedGridUid = loadedGrid.Value.Owner;
+
+            // TryLoadGrid completes entity startup before returning, so anchor MapInit can
+            // run before we mark this grid as a restore candidate. Register pending restore
+            // metadata first, then force a registration pass for any already-started anchor
+            // on the loaded grid to keep anchor IDs stable.
+            _pendingRestoredGridAnchors[loadedGridUid] = anchorId;
+
+            if (TryFindAnchorOnGrid(loadedGridUid, out var anchorUid, out var anchorComp))
+                TryRegisterAnchor(anchorUid, anchorComp, immediateSave: false);
+
             _pendingRestoreHealAnchors.Add(anchorId);
-            _pendingRestoreUnlockGrids.Add(loadedGrid.Value.Owner);
+            _pendingRestoreUnlockGrids.Add(loadedGridUid);
 
             Log.Info($"[Persistence] Restored persistent grid '{record.GridName}' (anchor {anchorId}) from snapshot.");
             // _anchorToGrid / _gridToAnchor will be populated naturally when the
@@ -405,6 +415,24 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
         }
 
         return null;
+    }
+
+    private bool TryFindAnchorOnGrid(EntityUid gridUid, out EntityUid anchorUid, out PersistenceAnchorComponent component)
+    {
+        var query = EntityQueryEnumerator<PersistenceAnchorComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var anchorComp, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            anchorUid = uid;
+            component = anchorComp;
+            return true;
+        }
+
+        anchorUid = EntityUid.Invalid;
+        component = default!;
+        return false;
     }
 
     // ── Startup rebuild ──────────────────────────────────────────────────────

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -242,9 +242,19 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     private void OnRoundStarted(RoundStartedEvent ev)
     {
         _suppressShutdownArchival = false;
+        RegisterUntrackedAnchors();
         UnlockRestoredGridLocks();
         RestoreDockLinks();
         HealRestoredSnapshots();
+    }
+
+    private void RegisterUntrackedAnchors()
+    {
+        var query = EntityQueryEnumerator<PersistenceAnchorComponent>();
+        while (query.MoveNext(out var anchorUid, out var component))
+        {
+            TryRegisterAnchor(anchorUid, component, immediateSave: false);
+        }
     }
 
     /// <summary>
@@ -660,6 +670,12 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
     private void TryRegisterAnchor(EntityUid anchor, PersistenceAnchorComponent component, bool immediateSave)
     {
         var xform = Transform(anchor);
+
+        // Do not mutate component state while a map is still pre-init.
+        // This keeps prototype-spawn validation deterministic.
+        if (!_mapManager.IsMapInitialized(xform.MapID))
+            return;
+
         if (!TryResolveAnchorGrid(anchor, xform, out var grid))
             return;
 

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -381,16 +381,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
             if (!TryGetLiveAnchor(grid, anchorId, out var anchor, out var component))
                 continue;
 
-            _shipyard.EnsureRestoredShuttleStation(grid);
-            _deviceNetwork.ResyncGridDeviceNetwork(grid);
-            _extensionCables.ResyncGridConnections(grid);
-            _gravityGenerators.ResyncGridGravity(grid);
-            _shipShields.ResyncGridShields(grid);
-            _salvage.ResyncGridExpeditionConsoles(grid);
-            _fireControl.ResyncGridFireControl(grid);
-            _dockingSystem.ResyncGridDockAirlocks(grid);
-            _mech.ResyncGridMechs(grid);
-            _materialStorage.ResyncGridMaterialStorage(grid);
+            _shipyard.HealRestoredGrid(grid);
 
             SaveSnapshot(anchor, component, immediate: true);
             _pendingRestoreHealAnchors.Remove(anchorId);
@@ -1191,6 +1182,16 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
         signature = $"gid:{record.GridPersistentId}";
         return true;
+    }
+
+    /// <summary>
+    /// Applies the persistence snapshot sanitization pass to a grid.
+    /// Intended for other snapshot writers (e.g. shipyard stored ships)
+    /// so all restore paths heal the same runtime-only references.
+    /// </summary>
+    public void SanitizeGridForSnapshot(EntityUid grid)
+    {
+        SanitizeGridForPersistence(grid);
     }
 
     private void SanitizeGridForPersistence(EntityUid grid)

--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -681,6 +681,10 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
         {
             if (wasPendingRestore)
                 component.AnchorId = restoredId;
+            else if (TryComp<PersistenceAnchorIdentityComponent>(grid, out var identity)
+                     && !string.IsNullOrWhiteSpace(identity.PersistentId)
+                     && TryFindActiveAnchorIdByGridPersistentId(identity.PersistentId!, out var recoveredAnchorId))
+                component.AnchorId = recoveredAnchorId;
             else if (!immediateSave)
                 return;
             else
@@ -716,6 +720,25 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
         UpdateVisual(anchor, PersistenceAnchorState.Clean);
     }
 
+    private bool TryFindActiveAnchorIdByGridPersistentId(string persistentId, out string anchorId)
+    {
+        // In case of duplicate records, prefer the most recently saved one.
+        var match = _manifest.Records
+            .Where(pair => !pair.Value.Archived && string.Equals(pair.Value.GridPersistentId, persistentId, StringComparison.Ordinal))
+            .OrderByDescending(pair => pair.Value.LastSavedUtc)
+            .ThenBy(pair => pair.Key, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(match.Key))
+        {
+            anchorId = string.Empty;
+            return false;
+        }
+
+        anchorId = match.Key;
+        return true;
+    }
+
     private void SaveSnapshot(EntityUid anchor, PersistenceAnchorComponent component, bool immediate)
     {
         try
@@ -737,14 +760,13 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
             var gridPersistentId = identity.PersistentId;
             // Some live ships may carry runtime references/components that are not fully serializable.
-            // Use tolerant options so we persist as much as possible instead of failing the entire snapshot.
+            // We tolerate missing references, but must fail on per-entity serialization exceptions.
+            // Ignoring entity exceptions can silently produce partial snapshots (e.g. missing walls).
             var saveOptions = SerializationOptions.Default with
             {
                 Category = FileCategory.Grid,
                 MissingEntityBehaviour = MissingEntityBehaviour.Ignore,
-                EntityExceptionBehaviour = EntityExceptionBehaviour.IgnoreEntityAndChildren,
                 ErrorOnOrphan = false,
-                LogAutoInclude = null,
             };
 
             SanitizeGridForPersistence(grid);

--- a/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
@@ -20,10 +20,18 @@ public sealed partial class StorageSystem
 
         if (TryComp<StorageComponent>(uid, out var storageComp))
         {
+            // Persisted or serialized entities may already contain items.
+            if (storageComp.Container.ContainedEntities.Count > 0)
+                return;
+
             FillStorage((uid, component, storageComp));
         }
         else if (TryComp<EntityStorageComponent>(uid, out var entityStorageComp))
         {
+            // Avoid re-filling restored entity-storage contents.
+            if (entityStorageComp.Contents.ContainedEntities.Count > 0)
+                return;
+
             FillEntityStorage((uid, component, entityStorageComp));
         }
         else
@@ -80,6 +88,9 @@ public sealed partial class StorageSystem
                 else
                     reason += $", {reasons}";
             }
+
+            if (string.IsNullOrWhiteSpace(reason))
+                reason = "unknown";
 
             Log.Error($"Tried to StorageFill {ToPrettyString(ent)} inside {ToPrettyString(uid)} but can't. reason: {reason}");
             ClearCantFillReasons();

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -59,6 +59,10 @@ using Robust.Shared.EntitySerialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Server._Mono.FireControl;
+using Content.Shared.CartridgeLoader.Cartridges;
+using Content.Shared.Storage.Components;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Ranged.Components;
 
 namespace Content.Server._NF.Shipyard.Systems;
 
@@ -115,7 +119,106 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _docking.ResyncGridDockAirlocks(gridUid);
         _mech.ResyncGridMechs(gridUid);
         _materialStorage.ResyncGridMaterialStorage(gridUid);
-            _useDelay.ExpireGridUseDelays(gridUid);
+        _useDelay.ExpireGridUseDelays(gridUid);
+        ResyncGridItemCooldowns(gridUid);
+    }
+
+    /// <summary>
+    /// Clears stale per-item cooldown timestamps on a restored grid.
+    /// Some item systems serialize absolute TimeSpan cooldown markers and can
+    /// become effectively unusable after cross-session ship restore.
+    /// </summary>
+    private void ResyncGridItemCooldowns(EntityUid gridUid)
+    {
+        var gunQuery = EntityQueryEnumerator<GunComponent, TransformComponent>();
+        while (gunQuery.MoveNext(out var uid, out var gun, out var xform))
+        {
+            if (!IsEntityOnGrid(uid, gridUid, xform))
+                continue;
+
+            if (gun.NextFire < _timing.CurTime)
+                continue;
+
+            gun.NextFire = _timing.CurTime;
+            Dirty(uid, gun);
+        }
+
+        var meleeQuery = EntityQueryEnumerator<MeleeWeaponComponent, TransformComponent>();
+        while (meleeQuery.MoveNext(out var uid, out var melee, out var xform))
+        {
+            if (!IsEntityOnGrid(uid, gridUid, xform))
+                continue;
+
+            if (melee.NextAttack < _timing.CurTime)
+                continue;
+
+            melee.NextAttack = _timing.CurTime;
+            Dirty(uid, melee);
+        }
+
+        var rechargeQuery = EntityQueryEnumerator<RechargeBasicEntityAmmoComponent, TransformComponent>();
+        while (rechargeQuery.MoveNext(out var uid, out var recharge, out var xform))
+        {
+            if (!IsEntityOnGrid(uid, gridUid, xform))
+                continue;
+
+            if (recharge.NextCharge is not { } next || next < _timing.CurTime)
+                continue;
+
+            recharge.NextCharge = _timing.CurTime;
+            Dirty(uid, recharge);
+        }
+
+        var cartridgeQuery = EntityQueryEnumerator<NanoTaskCartridgeComponent, TransformComponent>();
+        while (cartridgeQuery.MoveNext(out var uid, out var cartridge, out var xform))
+        {
+            if (!IsEntityOnGrid(uid, gridUid, xform))
+                continue;
+
+            if (cartridge.NextPrintAllowedAfter < _timing.CurTime)
+                continue;
+
+            cartridge.NextPrintAllowedAfter = _timing.CurTime;
+            Dirty(uid, cartridge);
+        }
+
+        var entityStorageQuery = EntityQueryEnumerator<SharedEntityStorageComponent, TransformComponent>();
+        while (entityStorageQuery.MoveNext(out var uid, out var entityStorage, out var xform))
+        {
+            if (!IsEntityOnGrid(uid, gridUid, xform))
+                continue;
+
+            if (entityStorage.NextInternalOpenAttempt < _timing.CurTime)
+                continue;
+
+            entityStorage.NextInternalOpenAttempt = _timing.CurTime;
+            Dirty(uid, entityStorage);
+        }
+    }
+
+    private bool IsEntityOnGrid(EntityUid uid, EntityUid gridUid, TransformComponent xform)
+    {
+        if (xform.GridUid == gridUid || uid == gridUid)
+            return true;
+
+        var parent = xform.ParentUid;
+        var query = GetEntityQuery<TransformComponent>();
+        var depth = 0;
+        while (parent.IsValid() && depth++ < 64)
+        {
+            if (parent == gridUid)
+                return true;
+
+            if (!query.TryGetComponent(parent, out var parentXform))
+                return false;
+
+            if (parentXform.GridUid == gridUid)
+                return true;
+
+            parent = parentXform.ParentUid;
+        }
+
+        return false;
     }
 
     private EntityUid? GetOwningStationForConsole(EntityUid uid)

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -40,6 +40,7 @@ using System.Text.RegularExpressions;
 using Content.Server._Mono.Shipyard;
 using Content.Server.Materials;
 using Content.Server.Mech.Systems;
+using Content.Shared.Timing;
 using Content.Server.Shuttles.Systems;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
@@ -87,6 +88,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly FireControlSystem _fireControl = default!;
     [Dependency] private readonly MaterialStorageSystem _materialStorage = default!;
     [Dependency] private readonly MechSystem _mech = default!;
+    [Dependency] private readonly UseDelaySystem _useDelay = default!;
 
     private static readonly ProtoId<TagPrototype> CrewedShuttleTag = "CrewedShuttle";
     private static readonly Regex DeedRegex = new(@"\s*\([^()]*\)");
@@ -113,6 +115,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _docking.ResyncGridDockAirlocks(gridUid);
         _mech.ResyncGridMechs(gridUid);
         _materialStorage.ResyncGridMaterialStorage(gridUid);
+            _useDelay.ExpireGridUseDelays(gridUid);
     }
 
     private EntityUid? GetOwningStationForConsole(EntityUid uid)

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -60,6 +60,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Server._Mono.FireControl;
 using Content.Shared.CartridgeLoader.Cartridges;
+using Content.Server.Storage.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Ranged.Components;
@@ -130,74 +131,94 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     /// </summary>
     private void ResyncGridItemCooldowns(EntityUid gridUid)
     {
-        var gunQuery = EntityQueryEnumerator<GunComponent, TransformComponent>();
-        while (gunQuery.MoveNext(out var uid, out var gun, out var xform))
+        var curTime = _timing.CurTime;
+
+        var gunQuery = EntityQueryEnumerator<GunComponent>();
+        while (gunQuery.MoveNext(out var uid, out var gun))
         {
+            if (!TryComp(uid, out TransformComponent? xform))
+                continue;
+
             if (!IsEntityOnGrid(uid, gridUid, xform))
                 continue;
 
-            if (gun.NextFire < _timing.CurTime)
+            if (gun.NextFire < curTime)
                 continue;
 
-            gun.NextFire = _timing.CurTime;
+            gun.NextFire = curTime;
             Dirty(uid, gun);
         }
 
-        var meleeQuery = EntityQueryEnumerator<MeleeWeaponComponent, TransformComponent>();
-        while (meleeQuery.MoveNext(out var uid, out var melee, out var xform))
+        var meleeQuery = EntityQueryEnumerator<MeleeWeaponComponent>();
+        while (meleeQuery.MoveNext(out var uid, out var melee))
         {
+            if (!TryComp(uid, out TransformComponent? xform))
+                continue;
+
             if (!IsEntityOnGrid(uid, gridUid, xform))
                 continue;
 
-            if (melee.NextAttack < _timing.CurTime)
+            if (melee.NextAttack < curTime)
                 continue;
 
-            melee.NextAttack = _timing.CurTime;
+            melee.NextAttack = curTime;
             Dirty(uid, melee);
         }
 
-        var rechargeQuery = EntityQueryEnumerator<RechargeBasicEntityAmmoComponent, TransformComponent>();
-        while (rechargeQuery.MoveNext(out var uid, out var recharge, out var xform))
+        var rechargeQuery = EntityQueryEnumerator<RechargeBasicEntityAmmoComponent>();
+        while (rechargeQuery.MoveNext(out var uid, out var recharge))
         {
+            if (!TryComp(uid, out TransformComponent? xform))
+                continue;
+
             if (!IsEntityOnGrid(uid, gridUid, xform))
                 continue;
 
-            if (recharge.NextCharge is not { } next || next < _timing.CurTime)
+            if (recharge.NextCharge is not { } next || next < curTime)
                 continue;
 
-            recharge.NextCharge = _timing.CurTime;
+            recharge.NextCharge = curTime;
             Dirty(uid, recharge);
         }
 
-        var cartridgeQuery = EntityQueryEnumerator<NanoTaskCartridgeComponent, TransformComponent>();
-        while (cartridgeQuery.MoveNext(out var uid, out var cartridge, out var xform))
+        var cartridgeQuery = EntityQueryEnumerator<NanoTaskCartridgeComponent>();
+        while (cartridgeQuery.MoveNext(out var uid, out var cartridge))
         {
+            if (!TryComp(uid, out TransformComponent? xform))
+                continue;
+
             if (!IsEntityOnGrid(uid, gridUid, xform))
                 continue;
 
-            if (cartridge.NextPrintAllowedAfter < _timing.CurTime)
+            if (cartridge.NextPrintAllowedAfter < curTime)
                 continue;
 
-            cartridge.NextPrintAllowedAfter = _timing.CurTime;
+            cartridge.NextPrintAllowedAfter = curTime;
             Dirty(uid, cartridge);
         }
 
-        var entityStorageQuery = EntityQueryEnumerator<SharedEntityStorageComponent, TransformComponent>();
-        while (entityStorageQuery.MoveNext(out var uid, out var entityStorage, out var xform))
+        var entityStorageQuery = EntityQueryEnumerator<EntityStorageComponent>();
+        while (entityStorageQuery.MoveNext(out var uid, out var entityStorage))
         {
+            if (!TryComp(uid, out TransformComponent? xform))
+                continue;
+
             if (!IsEntityOnGrid(uid, gridUid, xform))
                 continue;
 
-            if (entityStorage.NextInternalOpenAttempt < _timing.CurTime)
+            if (entityStorage.NextInternalOpenAttempt < curTime)
                 continue;
 
-            entityStorage.NextInternalOpenAttempt = _timing.CurTime;
+            entityStorage.NextInternalOpenAttempt = curTime;
             Dirty(uid, entityStorage);
         }
     }
 
-    private bool IsEntityOnGrid(EntityUid uid, EntityUid gridUid, TransformComponent xform)
+    private bool IsEntityOnGrid(EntityUid uid, EntityUid gridUid, TransformComponent? xform = null)
     {
+        if (!Resolve(uid, ref xform, false))
+            return false;
+
         if (xform.GridUid == gridUid || uid == gridUid)
             return true;
 

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -96,6 +96,25 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
     }
 
+    /// <summary>
+    /// Rebuild runtime links for grids loaded from snapshot data.
+    /// Keep all restore-time resync calls centralized so shipyard retrieval
+    /// and persistence-anchor restore paths cannot drift.
+    /// </summary>
+    public void HealRestoredGrid(EntityUid gridUid)
+    {
+        _ = EnsureRestoredShuttleStation(gridUid);
+        _deviceNetwork.ResyncGridDeviceNetwork(gridUid);
+        _extensionCables.ResyncGridConnections(gridUid);
+        _gravityGenerators.ResyncGridGravity(gridUid);
+        _shipShields.ResyncGridShields(gridUid);
+        _salvage.ResyncGridExpeditionConsoles(gridUid);
+        _fireControl.ResyncGridFireControl(gridUid);
+        _docking.ResyncGridDockAirlocks(gridUid);
+        _mech.ResyncGridMechs(gridUid);
+        _materialStorage.ResyncGridMaterialStorage(gridUid);
+    }
+
     private EntityUid? GetOwningStationForConsole(EntityUid uid)
     {
         if (_station.GetOwningStation(uid) is { Valid: true } stationUid)
@@ -651,6 +670,10 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             LogAutoInclude = null,
         };
 
+        // Shipyard snapshots should receive the same persistence sanitization pass
+        // as persistence-anchor snapshots to avoid stale runtime references.
+        _persistenceAnchor.SanitizeGridForSnapshot(shuttleUid);
+
         // Save from the shuttle grid root to avoid selecting transient runtime entities
         // (e.g. actions/audio) as serialization roots.
         if (!_mapLoader.TrySaveGrid(shuttleUid, snapshotPath, saveOptions))
@@ -796,16 +819,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         }
 
         _shuttle.TryFTLDock(shuttleUid, shuttle, targetGrid.Value);
-        _ = EnsureRestoredShuttleStation(shuttleUid);
-        _deviceNetwork.ResyncGridDeviceNetwork(shuttleUid);
-        _extensionCables.ResyncGridConnections(shuttleUid);
-        _gravityGenerators.ResyncGridGravity(shuttleUid);
-        _shipShields.ResyncGridShields(shuttleUid);
-        _salvage.ResyncGridExpeditionConsoles(shuttleUid);
-        _fireControl.ResyncGridFireControl(shuttleUid);
-        _docking.ResyncGridDockAirlocks(shuttleUid);
-        _mech.ResyncGridMechs(shuttleUid);
-        _materialStorage.ResyncGridMaterialStorage(shuttleUid);
+        HealRestoredGrid(shuttleUid);
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;
         var deedID = EnsureComp<ShuttleDeedComponent>(targetId);

--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -34,6 +34,10 @@ public sealed class ContainerFillSystem : EntitySystem
                 continue;
             }
 
+            // Containers can already be populated when loading persisted or serialized map entities.
+            if (container.ContainedEntities.Count > 0)
+                continue;
+
             foreach (var proto in prototypes)
             {
                 var ent = Spawn(proto, coords);
@@ -65,6 +69,10 @@ public sealed class ContainerFillSystem : EntitySystem
                 Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} is missing a container ({containerId}).");
                 continue;
             }
+
+            // Avoid duplicate table fills when map content already contains entities.
+            if (container.ContainedEntities.Count > 0)
+                continue;
 
             var spawns = _entityTable.GetSpawns(table);
             foreach (var proto in spawns)

--- a/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
+++ b/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
@@ -165,4 +165,76 @@ public abstract class SharedOreSiloSystem : EntitySystem
 
         return true;
     }
+
+    /// <summary>
+    /// Cleans up stale silo/client references on a grid after snapshot-based restores.
+    /// MapInit does not always rebuild these links for midround loads.
+    /// </summary>
+    public void SanitizeGridOreSiloLinks(EntityUid gridUid)
+    {
+        var siloQuery = EntityQueryEnumerator<OreSiloComponent, TransformComponent>();
+        while (siloQuery.MoveNext(out var siloUid, out var silo, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            var sanitizedClients = new HashSet<EntityUid>();
+            var changed = false;
+
+            foreach (var clientUid in silo.Clients)
+            {
+                if (!clientUid.IsValid() || !Exists(clientUid) || TerminatingOrDeleted(clientUid))
+                {
+                    changed = true;
+                    continue;
+                }
+
+                if (!_clientQuery.TryComp(clientUid, out var clientComp))
+                {
+                    changed = true;
+                    continue;
+                }
+
+                if (_transform.GetGrid(clientUid) != gridUid)
+                {
+                    changed = true;
+                    continue;
+                }
+
+                if (!sanitizedClients.Add(clientUid))
+                    changed = true;
+
+                if (clientComp.Silo == siloUid)
+                    continue;
+
+                clientComp.Silo = siloUid;
+                Dirty(clientUid, clientComp);
+            }
+
+            if (!changed)
+                continue;
+
+            silo.Clients = sanitizedClients;
+            Dirty(siloUid, silo);
+        }
+
+        var clientQuery = EntityQueryEnumerator<OreSiloClientComponent, TransformComponent>();
+        while (clientQuery.MoveNext(out var clientUid, out var clientComp, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            if (clientComp.Silo is not { } siloUid)
+                continue;
+
+            if (!siloUid.IsValid() || !Exists(siloUid) || TerminatingOrDeleted(siloUid)
+                || !TryComp<OreSiloComponent>(siloUid, out var siloComp)
+                || _transform.GetGrid(siloUid) != gridUid
+                || !siloComp.Clients.Contains(clientUid))
+            {
+                clientComp.Silo = null;
+                Dirty(clientUid, clientComp);
+            }
+        }
+    }
 }

--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -54,6 +54,15 @@ public sealed class BinSystem : EntitySystem
         if (_net.IsClient)
             return;
 
+        // Bins loaded from persisted or serialized maps may already contain papers.
+        if (component.ItemContainer.ContainedEntities.Count > 0)
+        {
+            component.Items.Clear();
+            component.Items.AddRange(component.ItemContainer.ContainedEntities);
+            Dirty(uid, component);
+            return;
+        }
+
         var xform = Transform(uid);
         foreach (var id in component.InitialContents)
         {

--- a/Content.Shared/Timing/UseDelaySystem.cs
+++ b/Content.Shared/Timing/UseDelaySystem.cs
@@ -193,7 +193,7 @@ public sealed class UseDelaySystem : EntitySystem
             var query = EntityQueryEnumerator<UseDelayComponent, TransformComponent>();
             while (query.MoveNext(out var uid, out var delay, out var xform))
             {
-                if (xform.GridUid != gridUid)
+                if (!IsEntityOnGrid(uid, gridUid, xform))
                     continue;
 
                 foreach (var entry in delay.Delays.Values)
@@ -201,5 +201,30 @@ public sealed class UseDelaySystem : EntitySystem
 
                 Dirty(uid, delay);
             }
+        }
+
+        private bool IsEntityOnGrid(EntityUid uid, EntityUid gridUid, TransformComponent xform)
+        {
+            if (xform.GridUid == gridUid || uid == gridUid)
+                return true;
+
+            var parent = xform.ParentUid;
+            var query = GetEntityQuery<TransformComponent>();
+            var depth = 0;
+            while (parent.IsValid() && depth++ < 64)
+            {
+                if (parent == gridUid)
+                    return true;
+
+                if (!query.TryGetComponent(parent, out var parentXform))
+                    return false;
+
+                if (parentXform.GridUid == gridUid)
+                    return true;
+
+                parent = parentXform.ParentUid;
+            }
+
+            return false;
         }
 }

--- a/Content.Shared/Timing/UseDelaySystem.cs
+++ b/Content.Shared/Timing/UseDelaySystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
+using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Timing;
 
@@ -181,4 +182,24 @@ public sealed class UseDelaySystem : EntitySystem
         }
         Dirty(ent);
     }
+
+        /// <summary>
+        /// Expires all active use-delays on every entity on a grid.
+        /// Called during ship snapshot restore to prevent stale serialized EndTime values
+        /// (from a previous server session) from permanently locking interactables.
+        /// </summary>
+        public void ExpireGridUseDelays(EntityUid gridUid)
+        {
+            var query = EntityQueryEnumerator<UseDelayComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var delay, out var xform))
+            {
+                if (xform.GridUid != gridUid)
+                    continue;
+
+                foreach (var entry in delay.Delays.Values)
+                    entry.EndTime = TimeSpan.Zero;
+
+                Dirty(uid, delay);
+            }
+        }
 }

--- a/Resources/Maps/_6MD/POI/HestiaFactory.yml
+++ b/Resources/Maps/_6MD/POI/HestiaFactory.yml
@@ -1,16 +1,16 @@
 meta:
   format: 7
-  category: Map
+  category: Grid
   engineVersion: 271.2.0
   forkId: ""
   forkVersion: ""
   time: 04/14/2026 22:31:18
   entityCount: 4342
-maps:
-- 1
+maps: []
 grids:
 - 2
-orphans: []
+orphans:
+- 2
 nullspace: []
 tilemap:
   5: Space
@@ -25,23 +25,13 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 1
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: Broadphase
-    - type: OccluderTree
   - uid: 2
     components:
     - type: MetaData
       name: grid
     - type: Transform
       pos: -0.47222233,-0.5
-      parent: 1
+      parent: invalid
     - type: BecomesStation
       id: HestiaFactory
     - type: MapGrid

--- a/Resources/Prototypes/_NF/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/_NF/Entities/Stations/nanotrasen.yml
@@ -87,6 +87,7 @@
   - BaseStation
   - BaseStationJobsSpawning
   - BaseStationRecords
+  - BaseStationMagnet
   - BaseStationAllEventsEligible
   - BaseStationRenameFaxes
   - BaseStationRenameHolopads

--- a/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -376,6 +376,7 @@
       - 0.78 # Nitrogen
       temperature: 5273 # ~ 5000 deg C, roughly when plasma turns back into gas
   - type: GasCanister
+    uiInteract: false
     gasMixture:
       volume: 10000 # big tank to store backup
     gasTankSlot:


### PR DESCRIPTION
## About the PR
This PR bundles the persistence and ship-retrieval fixes that were causing restore-time breakage and server log noise.

Included fixes:
- Lever interactions failing after retrieving stored ships.
- Gravity generators breaking on persistence-anchor restores.
- Stored-ship cooldown/state desync causing random item/system failures.
- Hestia persistence/spawn restore issues.
- Energy-to-air converter GUI click handling issues.
- Salvage magnet station-parent restoration issues.
- Duplicate map-init fill behavior in container/storage/bin systems.
- Persistence anchor identity/snapshot hardening to prevent silent partial snapshots.

## Closes issue
Closes #55  
Closes #54  
Closes #53  
Closes #52  
Closes #49  
Closes #48

## Why / Balance
These are stability/correctness fixes, not intended balance changes.  
They improve reliability of restored ships and reduce misleading warning spam while keeping meaningful diagnostics.

## Media
No media required (bugfix/refactor-focused PR).

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Store and retrieve a ship with lever-driven systems; verify levers still function.
2. Test gravity generators on a persistence-anchored ship, restart, and verify gravity remains correct.
3. Store/retrieve ships with cooldown-driven entities/items and verify cooldown behavior is stable.
4. Verify Hestia spawns and survives save/restore without serialization/map-format issues.
5. Interact with the energy-to-air converter UI and confirm click actions execute correctly.
6. Test salvage magnet behavior and confirm station-parent data restores correctly.
7. Restart with persisted ships and confirm duplicate fill spam is gone and invalid uid 0 warning flood is resolved.

## Breaking changes
None expected.

## Changelog
:cl:
- fix: Fixed lever interactions failing after retrieving stored ships.
- fix: Fixed gravity generators breaking on persistence-anchor restores.
- fix: Fixed stored-ship cooldown/state restore regressions.
- fix: Fixed Hestia persistence/spawn restore issues.
- fix: Fixed energy-to-air converter GUI click handling.
- fix: Fixed salvage magnet station-parent restoration issues.
- fix: Fixed duplicate map-init fill behavior and reduced invalid uid 0 warning spam.
- fix: Hardened persistence anchor snapshot integrity to prevent silent partial snapshots.