### PR TITLE
Enable Player Mob Pushing in Release Preset

### DIFF
--- a/Resources/ConfigPresets/_Mono/monolithCore.toml
+++ b/Resources/ConfigPresets/_Mono/monolithCore.toml
@@ -42,6 +42,9 @@ discord_channel_id = 1331042209172164639
 auto_call_time = 720
 mass_limit = 0
 
+[movement]
+mob_pushing = true
+
 [surgery]
 can_operate_on_self = true
 


### PR DESCRIPTION
## About the PR
This PR fixes player-to-player collision behavior in release by aligning the Monolith release preset with development behavior.

The last commit enables mob pushing in the release preset configuration:
- Added `[movement]`
- Set `mob_pushing = true`

## Closes issue
Closes #57

## Why / Balance
This restores expected movement/collision behavior consistency between dev and release environments.

No intentional balance change beyond fixing a config mismatch that disabled player collision pushing in release.

## Media
No media required (configuration bugfix only).

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Run server with the Monolith release preset.
2. Spawn two players and attempt to walk into/past each other.
3. Verify collisions/pushing now occur as expected (matching dev behavior).
4. Optionally compare with a config that has `movement.mob_pushing = false` to confirm the behavior difference.

## Breaking changes
None.

## Changelog
:cl:
- fix: Fixed player collisions not working in release due to movement mob pushing being disabled in release preset config.