### PR TITLE
Fix Expedition Console Atmosphere/Temperature Preview Mismatch (#59)

### DIFF
--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -544,10 +544,9 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
 
                         var spawnPosition = _map.GridTileToLocal(mapUid, grid, spawnTile); // Frontier: grid<_map
 
-                        var uid = _entManager.CreateEntityUninitialized(entry, spawnPosition);
+                        var uid = _entManager.SpawnAtPosition(entry, spawnPosition);
                         _entManager.RemoveComponent<GhostTakeoverAvailableComponent>(uid);
                         _entManager.RemoveComponent<GhostRoleComponent>(uid);
-                        _entManager.InitializeAndStartEntity(uid);
 
                         break;
                     }

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -3,6 +3,8 @@ using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Salvage.Expeditions;
 using Content.Shared.Salvage.Expeditions.Modifiers;
+using Content.Shared._NF.CCVar;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
@@ -12,6 +14,7 @@ namespace Content.Shared.Salvage;
 
 public abstract partial class SharedSalvageSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly ILocalizationManager _loc = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
 
@@ -104,23 +107,38 @@ public abstract partial class SharedSalvageSystem : EntitySystem
         var air = GetBiomeMod<SalvageAirMod>(biome.ID, rand, ref rating);
         var dungeon = GetBiomeMod<SalvageDungeonModPrototype>(biome.ID, rand, ref rating);
 
-        var mods = new List<string>();
-
-        if (air.Description != string.Empty)
-        {
-            mods.Add(Loc.GetString(air.Description));
-        }
+        // Keep client preview and server spawn behavior in sync when breathable atmos override is enabled.
+        var breathableAtmos = _cfg.GetCVar(NFCCVars.SalvageExpeditionBreathableAtmos);
+        var effectiveAir = air;
 
         // only show the description if there is an atmosphere since wont matter otherwise
         var temp = GetBiomeMod<SalvageTemperatureMod>(biome.ID, rand, ref rating);
-        if (temp.Description != string.Empty && !air.Space)
+        var effectiveTemp = temp;
+
+        if (breathableAtmos)
         {
-            mods.Add(Loc.GetString(temp.Description));
+            if (_proto.TryIndex<SalvageAirMod>("Mix1", out var breathableAir))
+                effectiveAir = breathableAir;
+
+            if (_proto.TryIndex<SalvageTemperatureMod>("RoomTemp", out var roomTemp))
+                effectiveTemp = roomTemp;
+        }
+
+        var mods = new List<string>();
+
+        if (effectiveAir.Description != string.Empty)
+        {
+            mods.Add(Loc.GetString(effectiveAir.Description));
+        }
+
+        if (effectiveTemp.Description != string.Empty && !effectiveAir.Space)
+        {
+            mods.Add(Loc.GetString(effectiveTemp.Description));
         }
 
         // only show the description if there is an atmosphere since wont matter otherwise
         var weather = GetBiomeMod<SalvageWeatherMod>(biome.ID, rand, ref rating);
-        if (weather.Description != string.Empty && !air.Space)
+        if (weather.Description != string.Empty && !effectiveAir.Space)
         {
             mods.Add(Loc.GetString(weather.Description));
         }
@@ -143,7 +161,7 @@ public abstract partial class SharedSalvageSystem : EntitySystem
         }
 
         var rewards = GetRewards(difficulty, rand);
-        return new SalvageMission(seed, difficulty, dungeon.ID, faction.ID, config, biome.ID, weather.ID, air.ID, temp.Temperature, light.Color, duration, rewards, mods);
+        return new SalvageMission(seed, difficulty, dungeon.ID, faction.ID, config, biome.ID, weather.ID, effectiveAir.ID, effectiveTemp.Temperature, light.Color, duration, rewards, mods);
     }
 
     public T GetBiomeMod<T>(string biome, System.Random rand, ref float rating) where T : class, IPrototype, IBiomeSpecificMod

--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -144,9 +144,10 @@ public sealed class NFCCVars
 
     /// <summary>
     /// Whether expedition planet maps should always use a breathable atmosphere.
+    /// Replicated so client mission previews can display the effective air/temperature correctly.
     /// </summary>
     public static readonly CVarDef<bool> SalvageExpeditionBreathableAtmos =
-        CVarDef.Create("nf14.salvage.expedition_breathable_atmos", true, CVar.SERVERONLY);
+        CVarDef.Create("nf14.salvage.expedition_breathable_atmos", true, CVar.SERVER | CVar.REPLICATED);
 
     /*
      * Smuggling


### PR DESCRIPTION
## About the PR
Fixes two expedition-related bugs:

1. **Expedition hostile mobs not spawning with AI (#67)**: Expedition mob entries use spawner-marker prototypes (such as `SpawnMobSyndicateNavalDeckhand`) that rely on `MapInit` via `RandomSpawner` or `ConditionalSpawner` to produce the actual NPC. The spawn code was using `CreateEntityUninitialized` + `InitializeAndStartEntity`, which would leave inert marker entities instead of resolving into live AI mobs. Changed to use `SpawnAtPosition`, the standard spawn path already used by dungeon generation for entities with spawn-time hooks.

2. **Expedition console displaying incorrect atmosphere and temperature values (#59)**: The mission preview was not applying the `SalvageExpeditionBreathableAtmos` override configuration, causing the console UI to show different conditions than what actually spawned on the expedition planet.

Closes #67
Closes #59

## Why / Balance
Both are bug fixes with no balance implications. Expedition enemies were present but non-functional, making expeditions trivial. Restoring proper AI behavior returns expeditions to their intended difficulty and threat level. The atmosphere/temperature fix ensures the console accurately reflects actual expedition conditions, removing confusion between preview and spawn.

## Media
No media needed. These are internal fixes to existing functionality.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
**For AI fix (#67):**
1. Claim a Syndicate expedition and land on the planet.
2. Confirm Syndicate Naval personnel now move, react to being attacked, and engage the player.
3. Spot-check another expedition faction (e.g., Cultists, Xenos) to confirm the same fix applies.
4. Verify enemies spawn in reasonable numbers and locations.

**For atmosphere/temperature fix (#59):**
1. Enable the `NFCCVars.SalvageExpeditionBreathableAtmos` server console variable.
2. View expedition missions in the expedition console.
3. Verify that the atmosphere and temperature values shown in the console UI match what is displayed when the expedition actually spawns.
4. Disable the override and confirm expeditions return to random atmosphere/temperature values in both preview and spawn.

## Breaking changes
None. These are internal implementation fixes with no changes to public APIs, prototypes, or game behavior beyond restoration of broken features.

## Changelog
:cl:
- fix: Expedition hostile mobs now spawn with functional AI instead of remaining as inert markers.
- fix: Fixed expedition console atmosphere and temperature display not reflecting actual spawned conditions.