### PR TITLE
Fix AI Controlled Ship AI Event Subscription

### DIFF
--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -37,7 +37,7 @@ public sealed class MoverController : SharedMoverController
         SubscribeLocalEvent<InputMoverComponent, PlayerDetachedEvent>(OnPlayerDetached);
         SubscribeLocalEvent<PilotComponent, GetShuttleInputsEvent>(OnPilotGetInputs); // Mono
 
-        SubscribeLocalEvent<PilotedShuttleComponent, StartCollideEvent>(PilotedShuttleRelayEvent<StartCollideEvent>); // Mono
+        SubscribeLocalEvent<PilotedShuttleComponent, StartCollideEvent>((ent, ref args) => PilotedShuttleRelayEvent(ent, ref args)); // Mono
     }
 
     private void OnRelayPlayerAttached(Entity<RelayInputMoverComponent> entity, ref PlayerAttachedEvent args)


### PR DESCRIPTION
## About the PR

Fixes the event subscription for `PilotedShuttleComponent` collision relay in `MoverController`. The previous registration passed a generic method group directly, which can fail to resolve correctly at runtime and silently drop the subscription for AI-controlled shuttle inputs. The fix wraps the call in a lambda to ensure proper binding.

Closes #69

## Why / Balance

No balance changes. This was a pure technical regression: AI-controlled ships could not receive collision events relayed to their input sources, which could cause the steering system to miss `FinishOnCollide` signals and leave the AI stuck in a moving-but-not-arriving state. No game mechanics, economy, or combat values were altered.

## Media

No visible UI or visual changes. The fix only restores expected AI ship driving behavior.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

1. Spawn or approach an AI-controlled ship that uses `ShipMoveToOperator` with `FinishOnCollide: true`.
2. Observe that the ship navigates and correctly transitions state on contact rather than continuing to push into the target indefinitely.
3. Alternatively, spawn an `NpcStationAiAttacker`-family drone ship and confirm it closes on a target and fires.

## Breaking changes

None. The lambda wrapper is call-compatible with the previous method group. No prototype, config, or API changes.

## Changelog

:cl:
- fix: AI-controlled ships now correctly receive collision relay events, fixing shuttles that would not stop or transition state after reaching a target.