### PR TITLE
Fix Ship Pipe Gas Persistence

### DIFF
--- a/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/PersistenceAnchorSystem.cs
@@ -403,6 +403,12 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
             _shipyard.HealRestoredGrid(grid);
 
+            var pipeSnapshotPath = GetActivePipeSnapshotPath(anchorId);
+            if (!_shipyard.TryRestoreGridPipeSnapshot(grid, pipeSnapshotPath))
+            {
+                Log.Warning($"[Persistence] Could not restore stored pipe gas state for anchor {anchorId} ({ToPrettyString(grid)}).");
+            }
+
             SaveSnapshot(anchor, component, immediate: true);
             _pendingRestoreHealAnchors.Remove(anchorId);
         }
@@ -767,6 +773,7 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
             var anchorId = component.AnchorId;
             var snapshotPath = GetActiveSnapshotPath(anchorId);
+            var pipeSnapshotPath = GetActivePipeSnapshotPath(anchorId);
 
             var identity = EnsureComp<PersistenceAnchorIdentityComponent>(grid);
             if (string.IsNullOrWhiteSpace(identity.PersistentId))
@@ -790,6 +797,12 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
             if (!_loader.TrySaveGrid(grid, snapshotPath, saveOptions))
             {
                 Log.Error($"[Persistence] Failed to save snapshot for {ToPrettyString(grid)} (anchor {ToPrettyString(anchor)}).");
+                return;
+            }
+
+            if (!_shipyard.SaveGridPipeSnapshot(grid, pipeSnapshotPath))
+            {
+                Log.Error($"[Persistence] Failed to save pipe snapshot for {ToPrettyString(grid)} (anchor {ToPrettyString(anchor)}).");
                 return;
             }
 
@@ -892,12 +905,22 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
         var activePath = GetActiveSnapshotPath(anchorId);
         var archivePath = GetArchiveSnapshotPath(anchorId);
+        var activePipePath = GetActivePipeSnapshotPath(anchorId);
+        var archivePipePath = GetArchivePipeSnapshotPath(anchorId);
         if (_res.UserData.Exists(activePath))
         {
             if (_res.UserData.Exists(archivePath))
                 _res.UserData.Delete(archivePath);
 
             _res.UserData.Rename(activePath, archivePath);
+        }
+
+        if (_res.UserData.Exists(activePipePath))
+        {
+            if (_res.UserData.Exists(archivePipePath))
+                _res.UserData.Delete(archivePipePath);
+
+            _res.UserData.Rename(activePipePath, archivePipePath);
         }
 
         record.Archived = true;
@@ -921,12 +944,22 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
 
             var activePath = GetActiveSnapshotPath(anchorId);
             var archivePath = GetArchiveSnapshotPath(anchorId);
+            var activePipePath = GetActivePipeSnapshotPath(anchorId);
+            var archivePipePath = GetArchivePipeSnapshotPath(anchorId);
             if (_res.UserData.Exists(activePath))
             {
                 if (_res.UserData.Exists(archivePath))
                     _res.UserData.Delete(archivePath);
 
                 _res.UserData.Rename(activePath, archivePath);
+            }
+
+            if (_res.UserData.Exists(activePipePath))
+            {
+                if (_res.UserData.Exists(archivePipePath))
+                    _res.UserData.Delete(archivePipePath);
+
+                _res.UserData.Rename(activePipePath, archivePipePath);
             }
 
             record.Archived = true;
@@ -1589,9 +1622,19 @@ public sealed partial class PersistenceAnchorSystem : EntitySystem
         return new ResPath($"{ActiveDirectory}/{anchorId}.yml");
     }
 
+    private static ResPath GetActivePipeSnapshotPath(string anchorId)
+    {
+        return new ResPath($"{ActiveDirectory}/{anchorId}.atmos.json");
+    }
+
     private static ResPath GetArchiveSnapshotPath(string anchorId)
     {
         return new ResPath($"{ArchiveDirectory}/{anchorId}.yml");
+    }
+
+    private static ResPath GetArchivePipeSnapshotPath(string anchorId)
+    {
+        return new ResPath($"{ArchiveDirectory}/{anchorId}.atmos.json");
     }
 
     private bool? IsPredefinedStation(EntityUid stationUid)

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -61,6 +61,7 @@ using Robust.Shared.Utility;
 using Content.Server._Mono.FireControl;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Server.Storage.Components;
+using Content.Server.NodeContainer.EntitySystems;
 using Content.Shared.Storage.Components;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Ranged.Components;
@@ -93,6 +94,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly FireControlSystem _fireControl = default!;
     [Dependency] private readonly MaterialStorageSystem _materialStorage = default!;
     [Dependency] private readonly MechSystem _mech = default!;
+    [Dependency] private readonly NodeGroupSystem _nodeGroups = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
 
     private static readonly ProtoId<TagPrototype> CrewedShuttleTag = "CrewedShuttle";
@@ -787,6 +789,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         var userKey = ToStoredUserKey(userId);
         var slotId = Guid.NewGuid().ToString("N");
         var snapshotPath = GetStoredShipSnapshotPath(userKey, slotId);
+        var pipeSnapshotPath = GetStoredShipPipeSnapshotPath(userKey, slotId);
 
         var saveOptions = SerializationOptions.Default with
         {
@@ -805,6 +808,16 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         // (e.g. actions/audio) as serialization roots.
         if (!_mapLoader.TrySaveGrid(shuttleUid, snapshotPath, saveOptions))
         {
+            ConsolePopup(player, Loc.GetString("shipyard-console-storage-save-failed"));
+            PlayDenySound(player, uid, component);
+            return;
+        }
+
+        if (!SaveGridPipeSnapshot(shuttleUid, pipeSnapshotPath))
+        {
+            if (_res.UserData.Exists(snapshotPath))
+                _res.UserData.Delete(snapshotPath);
+
             ConsolePopup(player, Loc.GetString("shipyard-console-storage-save-failed"));
             PlayDenySound(player, uid, component);
             return;
@@ -904,9 +917,13 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         }
 
         var snapshotPath = new ResPath(record.SnapshotPath);
+        var userKey = ToStoredUserKey(userId);
+        var pipeSnapshotPath = GetStoredShipPipeSnapshotPath(userKey, record.SlotId);
         if (!_res.UserData.Exists(snapshotPath))
         {
             RemoveStoredShip(userId, record.SlotId);
+            if (_res.UserData.Exists(pipeSnapshotPath))
+                _res.UserData.Delete(pipeSnapshotPath);
             ConsolePopup(player, Loc.GetString("shipyard-console-storage-missing"));
             PlayDenySound(player, uid, component);
             return;
@@ -947,6 +964,10 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
         _shuttle.TryFTLDock(shuttleUid, shuttle, targetGrid.Value);
         HealRestoredGrid(shuttleUid);
+        if (!TryRestoreGridPipeSnapshot(shuttleUid, pipeSnapshotPath))
+        {
+            _sawmill.Warning($"[ShipyardStorage] Could not restore all stored pipe gas state for {ToPrettyString(shuttleUid)}");
+        }
 
         var ownerName = string.IsNullOrWhiteSpace(record.OwnerName) ? Name(player).Trim() : record.OwnerName;
         var deedID = EnsureComp<ShuttleDeedComponent>(targetId);
@@ -971,6 +992,8 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         RemoveStoredShip(userId, record.SlotId);
         if (_res.UserData.Exists(snapshotPath))
             _res.UserData.Delete(snapshotPath);
+        if (_res.UserData.Exists(pipeSnapshotPath))
+            _res.UserData.Delete(pipeSnapshotPath);
 
         ConsolePopup(player, Loc.GetString("shipyard-console-storage-retrieve-success", ("ship", record.ShipName)));
         PlayConfirmSound(player, uid, component);
@@ -1013,8 +1036,12 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             }
 
             var snapshotPath = new ResPath(record.SnapshotPath);
+            var userKey = ToStoredUserKey(userId);
+            var pipeSnapshotPath = GetStoredShipPipeSnapshotPath(userKey, record.SlotId);
             if (_res.UserData.Exists(snapshotPath))
                 _res.UserData.Delete(snapshotPath);
+            if (_res.UserData.Exists(pipeSnapshotPath))
+                _res.UserData.Delete(pipeSnapshotPath);
 
             RemoveStoredShip(userId, record.SlotId);
 
@@ -1029,8 +1056,12 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         else
         {
             var snapshotPath = new ResPath(record.SnapshotPath);
+            var userKey = ToStoredUserKey(userId);
+            var pipeSnapshotPath = GetStoredShipPipeSnapshotPath(userKey, record.SlotId);
             if (_res.UserData.Exists(snapshotPath))
                 _res.UserData.Delete(snapshotPath);
+            if (_res.UserData.Exists(pipeSnapshotPath))
+                _res.UserData.Delete(pipeSnapshotPath);
 
             RemoveStoredShip(userId, record.SlotId);
 

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.StoredShips.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.StoredShips.cs
@@ -1,6 +1,12 @@
 using System.Text.Json;
 using System.Linq;
+using System.Globalization;
+using Content.Server.NodeContainer;
+using Content.Server.NodeContainer.NodeGroups;
+using Content.Server.NodeContainer.Nodes;
+using Content.Shared.Atmos;
 using Robust.Shared.ContentPack;
+using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
@@ -90,6 +96,147 @@ public sealed partial class ShipyardSystem
     private static ResPath GetStoredShipSnapshotPath(string userKey, string slotId)
     {
         return new ResPath($"{StoredShipsRootDirectory}/{userKey}_{slotId}.yml");
+    }
+
+    private static ResPath GetStoredShipPipeSnapshotPath(string userKey, string slotId)
+    {
+        return new ResPath($"{StoredShipsRootDirectory}/{userKey}_{slotId}.atmos.json");
+    }
+
+    public bool SaveGridPipeSnapshot(EntityUid gridUid, ResPath path)
+    {
+        try
+        {
+            var snapshot = CaptureStoredShipPipeSnapshot(gridUid);
+            if (snapshot.Nets.Count == 0)
+            {
+                if (_res.UserData.Exists(path))
+                    _res.UserData.Delete(path);
+
+                return true;
+            }
+
+            var json = JsonSerializer.Serialize(snapshot, StoredShipsJsonOptions);
+            _res.UserData.WriteAllText(path, json);
+            return true;
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"[ShipyardStorage] Failed to save pipe snapshot for {ToPrettyString(gridUid)}: {e}");
+            return false;
+        }
+    }
+
+    public bool TryRestoreGridPipeSnapshot(EntityUid gridUid, ResPath path)
+    {
+        if (!_res.UserData.Exists(path))
+            return true;
+
+        try
+        {
+            _nodeGroups.ForceUpdate();
+
+            var json = _res.UserData.ReadAllText(path);
+            var snapshot = JsonSerializer.Deserialize<StoredShipPipeSnapshot>(json, StoredShipsJsonOptions);
+            if (snapshot == null)
+                return false;
+
+            ApplyStoredShipPipeSnapshot(gridUid, snapshot);
+            return true;
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"[ShipyardStorage] Failed to restore pipe snapshot for {ToPrettyString(gridUid)}: {e}");
+            return false;
+        }
+    }
+
+    private StoredShipPipeSnapshot CaptureStoredShipPipeSnapshot(EntityUid gridUid)
+    {
+        var snapshot = new StoredShipPipeSnapshot();
+        var seenNets = new HashSet<PipeNet>();
+
+        var query = EntityQueryEnumerator<NodeContainerComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var nodes, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            foreach (var node in nodes.Nodes.Values)
+            {
+                if (node is not PipeNode pipe || pipe.NodeGroup is not PipeNet net)
+                    continue;
+
+                if (!seenNets.Add(net))
+                    continue;
+
+                var air = net.Air;
+                var moles = new float[Atmospherics.AdjustedNumberOfGases];
+                for (var i = 0; i < moles.Length; i++)
+                {
+                    moles[i] = air.GetMoles(i);
+                }
+
+                snapshot.Nets.Add(new StoredShipPipeNetRecord
+                {
+                    Signature = BuildPipeSignature(xform.Coordinates, pipe),
+                    Volume = air.Volume,
+                    Temperature = air.Temperature,
+                    Moles = moles,
+                });
+            }
+        }
+
+        return snapshot;
+    }
+
+    private void ApplyStoredShipPipeSnapshot(EntityUid gridUid, StoredShipPipeSnapshot snapshot)
+    {
+        var netsBySignature = new Dictionary<string, PipeNet>(StringComparer.Ordinal);
+
+        var query = EntityQueryEnumerator<NodeContainerComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var nodes, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            foreach (var node in nodes.Nodes.Values)
+            {
+                if (node is not PipeNode pipe || pipe.NodeGroup is not PipeNet net)
+                    continue;
+
+                var signature = BuildPipeSignature(xform.Coordinates, pipe);
+                netsBySignature.TryAdd(signature, net);
+            }
+        }
+
+        var restored = new HashSet<PipeNet>();
+        foreach (var record in snapshot.Nets)
+        {
+            if (string.IsNullOrWhiteSpace(record.Signature))
+                continue;
+
+            if (!netsBySignature.TryGetValue(record.Signature, out var net))
+                continue;
+
+            if (!restored.Add(net))
+                continue;
+
+            var moles = new float[Atmospherics.AdjustedNumberOfGases];
+            if (record.Moles != null)
+            {
+                Array.Copy(record.Moles, moles, Math.Min(record.Moles.Length, moles.Length));
+            }
+
+            var restoredAir = new GasMixture(moles, Math.Clamp(record.Temperature, Atmospherics.TCMB, Atmospherics.Tmax), MathF.Max(0f, record.Volume));
+            net.Air = restoredAir;
+        }
+    }
+
+    private static string BuildPipeSignature(EntityCoordinates coordinates, PipeNode node)
+    {
+        var pos = coordinates.Position;
+        return FormattableString.Invariant($"{pos.X:F3}|{pos.Y:F3}|{node.Name}|{(int)node.CurrentPipeLayer}");
     }
 
     private bool TryPeekStoredShip(Guid userId, out StoredShipRecord? record)
@@ -208,5 +355,20 @@ public sealed partial class ShipyardSystem
         public int SellValue { get; set; }
         public bool PurchasedWithVoucher { get; set; }
         public DateTime StoredAtUtc { get; set; }
+    }
+
+    [Serializable]
+    private sealed class StoredShipPipeSnapshot
+    {
+        public List<StoredShipPipeNetRecord> Nets { get; set; } = new();
+    }
+
+    [Serializable]
+    private sealed class StoredShipPipeNetRecord
+    {
+        public string Signature { get; set; } = string.Empty;
+        public float Volume { get; set; }
+        public float Temperature { get; set; }
+        public float[]? Moles { get; set; }
     }
 }


### PR DESCRIPTION
## About the PR

Preserves pipe-network gas when ships are snapshotted and restored.

This adds a pipe-gas sidecar snapshot alongside stored ship snapshots and persistence-anchor snapshots. On save, the current pipe networks on the grid are serialized into an `.atmos.json` file keyed by stable pipe-node signatures. On restore, the grid is healed, node groups are rebuilt, and the saved gas mixtures are reapplied to the matching pipe networks. The same sidecar is archived or deleted together with the main snapshot so storage and persistence-anchor flows stay consistent.

Closes #73

## Why / Balance

This fixes a persistence bug where storing and retrieving a ship, or restoring it through a persistence anchor, would silently wipe the gas inside its pipe networks. That breaks ship atmos setups, fuel systems, and any pre-pressurized pipe infrastructure players expect to survive storage or round persistence.

No intended balance changes beyond preserving existing ship state correctly.

## Media

No media needed. This is a persistence fix with no new UI or visual content.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

1. Set up a ship with a pipe network containing gas at a known pressure/composition.
2. Store the ship through shipyard storage, then retrieve it, and confirm the pipe network still contains the same gas instead of coming back empty.
3. Repeat with a ship/persistent grid restored through a persistence anchor and confirm the pipe gas is preserved there as well.
4. Verify archived or deleted stored snapshots do not leave stray `.atmos.json` sidecar files behind.

In-game verification was not run by me here.

## Breaking changes

None.

## Changelog
:cl:
- fix: Fixed ship pipe networks losing their stored gas after shipyard storage or persistence-anchor restoration.