### PR TITLE
Fix Salvage Magnet Offer Details and Biome Text Overflow

### DIFF
--- a/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
@@ -1,14 +1,19 @@
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Content.Client.Message;
 using Content.Shared.Salvage;
 using Content.Shared.Salvage.Magnet;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Salvage.UI;
 
 public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
 {
+    private static readonly Regex IdWordBreakRegex = new("([a-z0-9])([A-Z])|([A-Za-z])([0-9])", RegexOptions.Compiled);
+
     [Dependency] private readonly IEntityManager _entManager = default!;
 
     private OfferingWindow? _window;
@@ -100,9 +105,79 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
                     break;
                 case DebrisOffering debris:
                     option.Title = Loc.GetString($"salvage-magnet-debris-{debris.Id}");
+
+                    var debrisClassContainer = new BoxContainer
+                    {
+                        Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                        HorizontalExpand = true,
+                    };
+
+                    var debrisClassLabel = new Label
+                    {
+                        Text = Loc.GetString("salvage-magnet-debris-desc-class"),
+                        HorizontalAlignment = Control.HAlignment.Left,
+                    };
+
+                    var debrisClassValueLabel = new Label
+                    {
+                        Text = Loc.GetString($"salvage-magnet-debris-{debris.Id}"),
+                        HorizontalAlignment = Control.HAlignment.Right,
+                        HorizontalExpand = true,
+                    };
+
+                    debrisClassContainer.AddChild(debrisClassLabel);
+                    debrisClassContainer.AddChild(debrisClassValueLabel);
+                    option.AddContent(debrisClassContainer);
+
+                    var debrisOriginContainer = new BoxContainer
+                    {
+                        Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                        HorizontalExpand = true,
+                    };
+
+                    var debrisOriginLabel = new Label
+                    {
+                        Text = Loc.GetString("salvage-magnet-debris-desc-origin"),
+                        HorizontalAlignment = Control.HAlignment.Left,
+                    };
+
+                    var debrisOriginValueLabel = new Label
+                    {
+                        Text = Loc.GetString("salvage-magnet-debris-origin-generic"),
+                        HorizontalAlignment = Control.HAlignment.Right,
+                        HorizontalExpand = true,
+                    };
+
+                    debrisOriginContainer.AddChild(debrisOriginLabel);
+                    debrisOriginContainer.AddChild(debrisOriginValueLabel);
+                    option.AddContent(debrisOriginContainer);
                     break;
                 case SalvageOffering salvage:
                     option.Title = Loc.GetString($"salvage-map-wreck");
+
+                    var designationContainer = new BoxContainer
+                    {
+                        Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                        HorizontalExpand = true,
+                    };
+
+                    var designationLabel = new Label
+                    {
+                        Text = Loc.GetString("salvage-map-wreck-desc-designation"),
+                        HorizontalAlignment = Control.HAlignment.Left,
+                    };
+
+                    var designationValueLabel = new Label
+                    {
+                        Text = HumanizeMapId(salvage.SalvageMap.ID),
+                        HorizontalAlignment = Control.HAlignment.Right,
+                        HorizontalExpand = true,
+                    };
+
+                    designationContainer.AddChild(designationLabel);
+                    designationContainer.AddChild(designationValueLabel);
+
+                    option.AddContent(designationContainer);
 
                     var salvContainer = new BoxContainer
                     {
@@ -127,6 +202,30 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
                     salvContainer.AddChild(sizeValueLabel);
 
                     option.AddContent(salvContainer);
+
+                    var mapFileContainer = new BoxContainer
+                    {
+                        Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                        HorizontalExpand = true,
+                    };
+
+                    var mapFileLabel = new Label
+                    {
+                        Text = Loc.GetString("salvage-map-wreck-desc-map"),
+                        HorizontalAlignment = Control.HAlignment.Left,
+                    };
+
+                    var mapFileValueLabel = new Label
+                    {
+                        Text = salvage.SalvageMap.MapPath.Filename,
+                        HorizontalAlignment = Control.HAlignment.Right,
+                        HorizontalExpand = true,
+                    };
+
+                    mapFileContainer.AddChild(mapFileLabel);
+                    mapFileContainer.AddChild(mapFileValueLabel);
+
+                    option.AddContent(mapFileContainer);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -134,5 +233,34 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
 
             _window.AddOption(option);
         }
+    }
+
+    private static string HumanizeMapId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return "?";
+
+        var spaced = IdWordBreakRegex.Replace(id, "$1$3 $2$4").Replace('_', ' ').Trim();
+        if (spaced.Length == 0)
+            return id;
+
+        var builder = new StringBuilder(spaced.Length);
+        var shouldCapitalize = true;
+
+        foreach (var c in spaced)
+        {
+            if (char.IsLetter(c))
+            {
+                builder.Append(shouldCapitalize ? char.ToUpperInvariant(c) : c);
+                shouldCapitalize = false;
+            }
+            else
+            {
+                builder.Append(c);
+                shouldCapitalize = c == ' ' || c == '-';
+            }
+        }
+
+        return builder.ToString();
     }
 }

--- a/Content.Client/_Crescent/SpaceBiomes/SpaceBiomeTextDisplaySystem.cs
+++ b/Content.Client/_Crescent/SpaceBiomes/SpaceBiomeTextDisplaySystem.cs
@@ -4,6 +4,7 @@ using Content.Client.Audio;
 using Robust.Client.Graphics;
 using Robust.Shared.Timing;
 using Content.Shared._Crescent.Vessel;
+using System;
 
 namespace Content.Client._Crescent.SpaceBiomes;
 
@@ -32,11 +33,8 @@ public sealed class SpaceTextDisplaySystem : EntitySystem
         _overlay.ResetDescription();
         _overlay.Text = biome.Name;
         _overlay.TextDescription = biome.Description;
-        _overlay.CharInterval = TimeSpan.FromSeconds(2f / biome.Name.Length);
-        if (_overlay.TextDescription == "")                   //if we have a biome with no description, it's default is "" and that has length 0.
-            _overlay.CharIntervalDescription = TimeSpan.Zero;       //we need to calculate it here because otherwise...
-        else
-            _overlay.CharIntervalDescription = TimeSpan.FromSeconds(2f / biome.Description.Length);      //this would throw an exception
+        _overlay.CharInterval = CalculateCharInterval(_overlay.Text);
+        _overlay.CharIntervalDescription = CalculateCharInterval(_overlay.TextDescription);
     }
 
     private void OnNewVesselEntered(ref PlayerParentChangedMessage ev)
@@ -58,11 +56,19 @@ public sealed class SpaceTextDisplaySystem : EntitySystem
 
         _overlay.Text = name;
         _overlay.TextDescription = description; // fallback is "" if no description is found.
-        _overlay.CharInterval = TimeSpan.FromSeconds(2f / _overlay.Text.Length);
+        _overlay.CharInterval = CalculateCharInterval(_overlay.Text);
+        _overlay.CharIntervalDescription = CalculateCharInterval(_overlay.TextDescription);
+    }
 
-        if (_overlay.TextDescription == "")
-            _overlay.CharIntervalDescription = TimeSpan.Zero; //if this is not done it tries dividing by 0 in the "else" clause
-        else
-            _overlay.CharIntervalDescription = TimeSpan.FromSeconds(2f / _overlay.TextDescription.Length);
+    private static TimeSpan CalculateCharInterval(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return TimeSpan.Zero;
+
+        var seconds = 2f / text.Length;
+        if (!float.IsFinite(seconds) || seconds <= 0f)
+            return TimeSpan.Zero;
+
+        return TimeSpan.FromSeconds(seconds);
     }
 }

--- a/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
@@ -43,65 +43,123 @@ public abstract partial class SharedSalvageSystem
         var rand = new System.Random(seed);
 
         var type = SharedRandomExtensions.Pick(_offeringWeights, rand);
-        switch (type)
+        if (type is AsteroidOffering)
         {
-            case AsteroidOffering:
-                var configId = _asteroidConfigs[rand.Next(_asteroidConfigs.Count)];
-                var configProto =_proto.Index(configId);
-                var layers = new Dictionary<string, int>();
+            if (TryCreateAsteroidOffering(rand, out var asteroidOffering))
+                return asteroidOffering;
 
-                var data = new DungeonData();
-                data.Apply(configProto.Data);
+            // Fall back to debris if asteroid configs are missing.
+            if (TryCreateDebrisOffering(rand, out var debrisOffering))
+                return debrisOffering;
 
-                var config = new DungeonConfig
-                {
-                    Data = data,
-                    Layers = new(configProto.Layers),
-                    MaxCount = configProto.MaxCount,
-                    MaxOffset = configProto.MaxOffset,
-                    MinCount = configProto.MinCount,
-                    MinOffset = configProto.MinOffset,
-                    ReserveTiles = configProto.ReserveTiles
-                };
-
-                var count = _asteroidOreCount.Next(rand);
-                var weightedProto = _proto.Index(_asteroidOreWeights);
-                for (var i = 0; i < count; i++)
-                {
-                    var ore = weightedProto.Pick(rand);
-                    config.Layers.Add(_proto.Index<OreDunGenPrototype>(ore));
-
-                    var layerCount = layers.GetOrNew(ore);
-                    layerCount++;
-                    layers[ore] = layerCount;
-                }
-
-                return new AsteroidOffering
-                {
-                    Id = configId,
-                    DungeonConfig = config,
-                    MarkerLayers = layers,
-                };
-            case DebrisOffering:
-                var id = rand.Pick(_debrisConfigs);
-                return new DebrisOffering
-                {
-                    Id = id
-                };
-            case SalvageOffering:
-                // Salvage map seed
-                _salvageMaps.Clear();
-                _salvageMaps.AddRange(_proto.EnumeratePrototypes<SalvageMapPrototype>());
-                _salvageMaps.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
-                var mapIndex = rand.Next(_salvageMaps.Count);
-                var map = _salvageMaps[mapIndex];
-
-                return new SalvageOffering
-                {
-                    SalvageMap = map,
-                };
-            default:
-                throw new NotImplementedException($"Salvage type {type} not implemented!");
+            // Final fallback is always salvage maps.
+            return CreateSalvageWreckOffering(rand);
         }
+
+        if (type is DebrisOffering)
+        {
+            if (TryCreateDebrisOffering(rand, out var debrisOffering))
+                return debrisOffering;
+
+            return CreateSalvageWreckOffering(rand);
+        }
+
+        if (type is SalvageOffering)
+            return CreateSalvageWreckOffering(rand);
+
+        throw new NotImplementedException($"Salvage type {type} not implemented!");
+    }
+
+    private SalvageOffering CreateSalvageWreckOffering(System.Random rand)
+    {
+        _salvageMaps.Clear();
+        _salvageMaps.AddRange(_proto.EnumeratePrototypes<SalvageMapPrototype>());
+        _salvageMaps.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
+
+        if (_salvageMaps.Count == 0)
+            throw new InvalidOperationException("No salvage map prototypes are available.");
+
+        var mapIndex = rand.Next(_salvageMaps.Count);
+        var map = _salvageMaps[mapIndex];
+
+        return new SalvageOffering
+        {
+            SalvageMap = map,
+        };
+    }
+
+    private bool TryCreateAsteroidOffering(System.Random rand, out AsteroidOffering offering)
+    {
+        offering = default;
+
+        var validConfigs = new List<ProtoId<DungeonConfigPrototype>>();
+        foreach (var asteroidConfigId in _asteroidConfigs)
+        {
+            if (_proto.TryIndex<DungeonConfigPrototype>(asteroidConfigId, out _))
+                validConfigs.Add(asteroidConfigId);
+        }
+
+        if (validConfigs.Count == 0)
+            return false;
+
+        var selectedConfigId = validConfigs[rand.Next(validConfigs.Count)];
+        var configProto = _proto.Index<DungeonConfigPrototype>(selectedConfigId);
+        var layers = new Dictionary<string, int>();
+
+        var data = new DungeonData();
+        data.Apply(configProto.Data);
+
+        var config = new DungeonConfig
+        {
+            Data = data,
+            Layers = new(configProto.Layers),
+            MaxCount = configProto.MaxCount,
+            MaxOffset = configProto.MaxOffset,
+            MinCount = configProto.MinCount,
+            MinOffset = configProto.MinOffset,
+            ReserveTiles = configProto.ReserveTiles
+        };
+
+        var count = _asteroidOreCount.Next(rand);
+        var weightedProto = _proto.Index(_asteroidOreWeights);
+        for (var i = 0; i < count; i++)
+        {
+            var ore = weightedProto.Pick(rand);
+            config.Layers.Add(_proto.Index<OreDunGenPrototype>(ore));
+
+            var layerCount = layers.GetOrNew(ore);
+            layerCount++;
+            layers[ore] = layerCount;
+        }
+
+        offering = new AsteroidOffering
+        {
+            Id = selectedConfigId,
+            DungeonConfig = config,
+            MarkerLayers = layers,
+        };
+
+        return true;
+    }
+
+    private bool TryCreateDebrisOffering(System.Random rand, out DebrisOffering offering)
+    {
+        offering = default;
+
+        var validConfigs = new List<ProtoId<DungeonConfigPrototype>>();
+        foreach (var debrisConfigId in _debrisConfigs)
+        {
+            if (_proto.TryIndex<DungeonConfigPrototype>(debrisConfigId, out _))
+                validConfigs.Add(debrisConfigId);
+        }
+
+        if (validConfigs.Count == 0)
+            return false;
+
+        offering = new DebrisOffering
+        {
+            Id = rand.Pick(validConfigs)
+        };
+        return true;
     }
 }

--- a/Resources/Locale/en-US/salvage/salvage-magnet.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-magnet.ftl
@@ -6,6 +6,8 @@ salvage-asteroid-name = Asteroid
 
 salvage-magnet-window-title = Salvage magnet
 salvage-expedition-window-progression = Progression
+offering-window-claim = Claim
+offering-window-claimed = Claimed
 
 salvage-magnet-resources = {$resource ->
     [OreIron] Iron
@@ -33,6 +35,9 @@ salvage-magnet-resources-count = {$count ->
 
 # Debris
 salvage-magnet-debris-ChunkDebris = Space debris
+salvage-magnet-debris-desc-class = Class:
+salvage-magnet-debris-desc-origin = Origin:
+salvage-magnet-debris-origin-generic = Orbital wreckage
 
 # Asteroids
 dungeon-config-proto-BlobAsteroid = Asteroid clump
@@ -42,7 +47,9 @@ dungeon-config-proto-SwissCheeseAsteroid = Asteroid fragments
 
 # Wrecks
 salvage-map-wreck = Salvage wreck
+salvage-map-wreck-desc-designation = Wreck:
 salvage-map-wreck-desc-size = Size:
+salvage-map-wreck-desc-map = Source:
 salvage-map-wreck-size-small = [color=lime]Small[/color]
 salvage-map-wreck-size-medium = [color=cornflowerblue]Medium[/color]
 salvage-map-wreck-size-large = [color=orchid]Large[/color]


### PR DESCRIPTION
## About the PR
This PR improves salvage magnet offer readability and hardens two crash-prone client paths.

It adds richer offer details in the salvage magnet UI:
- Salvage wreck offers now show a readable wreck designation and source map filename in addition to size.
- Space debris offers now show class and origin information.
- Missing localization for the offer claim button text has been added.

It also fixes stability issues:
- Salvage magnet offering generation now safely handles missing asteroid/debris dungeon prototypes by falling back to valid offer types instead of throwing.
- Space biome text overlay timing now uses safe interval calculation, preventing TimeSpan overflow when biome/vessel text is empty or otherwise invalid.

## Why / Balance
This is primarily a UX and stability change.

Balance impact:
- Low direct balance impact.
- Moderate decision-quality impact for salvage crews: the additional wreck/debris context makes offer selection more informed and less guesswork-driven.

Stability impact:
- Prevents client-side crashes from invalid salvage prototype references and text interval overflow, improving round reliability.

## Media
No media included. These are small UI text/detail and crash-fix changes; no new assets or major visual feature flow was introduced.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Open a salvage magnet and verify each offer card renders correctly.
2. Confirm wreck offers show:
   - Wreck designation
   - Size
   - Source map filename
3. Confirm debris offers show:
   - Class
   - Origin
4. Confirm claim button text localizes correctly as Claim / Claimed.
5. Validate missing-prototype resilience:
   - Ensure an unavailable asteroid config no longer crashes magnet UI generation.
   - Verify fallback offer generation still produces usable offers.
6. Validate space biome text stability:
   - Enter/exit grids and vessels with empty or missing descriptive text.
   - Confirm no TimeSpan overflow crash occurs.

## Breaking changes
None expected.
- No public API/namespace/prototype rename migration is required.
- Behavior change is additive/fallback-oriented.

## Changelog
:cl:
- fix: Prevented salvage magnet crashes when configured asteroid/debris prototypes are missing by adding safe fallback offer generation.
- tweak: Expanded salvage magnet offer details for wrecks and debris, and added missing claim button localization.
- fix: Prevented space biome text display TimeSpan overflow crashes on invalid or empty text input.