### PR TITLE
Fix Shuttle Autopilot Activation and Post-Storage Restore

### DIFF
--- a/Content.Server/_Mono/Shuttles/Systems/ShuttleConsoleSystem.Autopilot.cs
+++ b/Content.Server/_Mono/Shuttles/Systems/ShuttleConsoleSystem.Autopilot.cs
@@ -1,6 +1,7 @@
 using Content.Server._Mono.NPC.HTN.Operators;
 using Content.Server.NPC.HTN;
 using Content.Shared.Popups;
+using Content.Shared.Shuttles.Components;
 using Content.Server.Shuttles.Components;
 using Content.Shared._Mono.Shuttles;
 using Robust.Shared.Audio;
@@ -18,7 +19,10 @@ public sealed partial class ShuttleConsoleAutopilotSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ShuttleConsoleComponent, ShuttleConsoleAutopilotPositionMessage>(OnAutopilotMessage);
+        Subs.BuiEvents<ShuttleConsoleComponent>(ShuttleConsoleUiKey.Key, subs =>
+        {
+            subs.Event<ShuttleConsoleAutopilotPositionMessage>(OnAutopilotMessage);
+        });
         SubscribeLocalEvent<ShuttleConsoleComponent, SteeringDoneEvent>(OnSteeringDone);
     }
 

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -50,6 +50,9 @@ using Content.Shared._NF.ShuttleRecords;
 using Content.Server.StationEvents.Components;
 using Content.Shared._Mono.Company;
 using Content.Shared.Forensics.Components;
+using Content.Server.NPC;
+using Content.Server.NPC.HTN;
+using Content.Server.NPC.Systems;
 using Content.Shared.Shuttles.Components;
 using Robust.Shared.Player;
 using Content.Shared._Mono.Ships.Components;
@@ -95,6 +98,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     [Dependency] private readonly MaterialStorageSystem _materialStorage = default!;
     [Dependency] private readonly MechSystem _mech = default!;
     [Dependency] private readonly NodeGroupSystem _nodeGroups = default!;
+    [Dependency] private readonly NPCSystem _npc = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
 
     private static readonly ProtoId<TagPrototype> CrewedShuttleTag = "CrewedShuttle";
@@ -122,8 +126,26 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         _docking.ResyncGridDockAirlocks(gridUid);
         _mech.ResyncGridMechs(gridUid);
         _materialStorage.ResyncGridMaterialStorage(gridUid);
+        ResyncGridAutopilotControllers(gridUid);
         _useDelay.ExpireGridUseDelays(gridUid);
         ResyncGridItemCooldowns(gridUid);
+    }
+
+    /// <summary>
+    /// Rebinds shuttle-console HTN controllers to their live entity UIDs after snapshot restore.
+    /// The serialized blackboard can retain pre-storage owner UIDs, which breaks autopilot steering.
+    /// </summary>
+    private void ResyncGridAutopilotControllers(EntityUid gridUid)
+    {
+        var htnQuery = EntityQueryEnumerator<HTNComponent, ShuttleConsoleComponent, TransformComponent>();
+        while (htnQuery.MoveNext(out var uid, out var htn, out _, out var xform))
+        {
+            if (!IsEntityOnGrid(uid, gridUid, xform))
+                continue;
+
+            htn.Blackboard.SetValue(NPCBlackboard.Owner, uid);
+            _npc.WakeNPC(uid, htn);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
This PR fixes shuttle autopilot in two failure paths:

1. Autopilot target clicks from the shuttle console UI are now subscribed through the shuttle console BUI event pipeline, so server-side autopilot target messages are handled correctly.
2. After ship storage/retrieval, restored shuttle consoles now rebind HTN/NPC ownership on the restored grid, preventing stale owner references from breaking autopilot steering.

Closes #66

## Why / Balance
This is a bugfix for shuttle control reliability, not a balance change.  
Before this, pilots could lose autopilot functionality entirely (or after ship restore), which blocked normal ship navigation workflows.

## Media
No media required. This is a systems/backend behavior fix with no visual content changes.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Start a server with this branch.
2. Spawn/use a shuttle console with autopilot support.
3. Select an autopilot destination from the console map and confirm the shuttle begins autopilot movement.
4. Store the shuttle through shipyard storage, then retrieve it.
5. Use autopilot again on the retrieved shuttle and confirm movement still works.
6. Verification performed in this branch also includes a successful `dotnet build Content.Server/Content.Server.csproj -v minimal -clp:ErrorsOnly`.

## Breaking changes
None.

## Changelog
:cl:
- fix: Fixed shuttle autopilot activation from console targeting and restored autopilot functionality after storing/retrieving ships.