### PR TITLE
Hestia Navmap Beacon Lighting

### DIFF
--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -169,11 +169,11 @@ public sealed partial class NavMapSystem : SharedNavMapSystem
 
     private void OnNavMapBeaconMapInit(EntityUid uid, NavMapBeaconComponent component, MapInitEvent args)
     {
-        if (component.DefaultText == null || component.Text != null)
-            return;
-
-        component.Text = Loc.GetString(component.DefaultText);
-        Dirty(uid, component);
+        if (component.DefaultText != null && component.Text == null)
+        {
+            component.Text = Loc.GetString(component.DefaultText);
+            Dirty(uid, component);
+        }
 
         UpdateNavMapBeaconData(uid, component);
     }

--- a/Content.Shared/Pinpointer/SharedNavMapSystem.cs
+++ b/Content.Shared/Pinpointer/SharedNavMapSystem.cs
@@ -73,7 +73,7 @@ public abstract class SharedNavMapSystem : EntitySystem
             return false;
 
         var name = component.Text;
-        if (string.IsNullOrEmpty(name))
+        if (string.IsNullOrWhiteSpace(name))
             name = meta.EntityName;
 
         beaconData = new NavMapBeacon(meta.NetEntity, component.Color, name, xform.LocalPosition);

--- a/Resources/Maps/_6MD/POI/HestiaFactory.yml
+++ b/Resources/Maps/_6MD/POI/HestiaFactory.yml
@@ -5,7 +5,7 @@ meta:
   forkId: ""
   forkVersion: ""
   time: 04/14/2026 22:31:18
-  entityCount: 4342
+  entityCount: 4347
 maps: []
 grids:
 - 2
@@ -8984,12 +8984,12 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-- proto: ComputerShipyard
+- proto: ComputerRadar
   entities:
   - uid: 4119
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
+      rot: 1.5707963267948966 rad
       pos: 19.5,5.5
       parent: 2
     - type: ApcPowerReceiver
@@ -8999,8 +8999,30 @@ entities:
   - uid: 4120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: -18.5,5.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerShipyard
+  entities:
+  - uid: 4349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,5.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+  - uid: 4350
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,5.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 5
@@ -9107,40 +9129,263 @@ entities:
     - type: Transform
       pos: -37.5,5.5
       parent: 2
+    - type: NavMapBeacon
+      text: Transit 1
   - uid: 4153
     components:
     - type: Transform
       pos: -37.5,46.5
       parent: 2
+    - type: NavMapBeacon
+      text: Gas buy dock 1
   - uid: 4154
     components:
     - type: Transform
       pos: -37.5,-40.5
       parent: 2
+    - type: NavMapBeacon
+      text: Gas sell dock 1
   - uid: 4155
     components:
     - type: Transform
       pos: 38.5,-40.5
       parent: 2
+    - type: NavMapBeacon
+      text: Gas sell dock 2
   - uid: 4156
     components:
     - type: Transform
       pos: 38.5,5.5
       parent: 2
+    - type: NavMapBeacon
+      text: Transit 2
   - uid: 4157
     components:
     - type: Transform
       pos: 38.5,46.5
       parent: 2
+    - type: NavMapBeacon
+      text: Gas buy dock 2
   - uid: 4218
     components:
     - type: Transform
       pos: 17.5,5.5
       parent: 2
+    - type: NavMapBeacon
+      text: Cargobay 2
   - uid: 4219
     components:
     - type: Transform
       pos: -16.5,5.5
+      parent: 2
+    - type: NavMapBeacon
+      text: Cargobay 1
+  - uid: 6000
+    components:
+    - type: Transform
+      pos: 0.5,45.5
+      parent: 2
+    - type: NavMapBeacon
+      text: Particle Accelerator
+- proto: PoweredlightLED
+  entities:
+  - uid: 6001
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,43.5
+      parent: 2
+  - uid: 6002
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,43.5
+      parent: 2
+  - uid: 6003
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,42.5
+      parent: 2
+  - uid: 6004
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,42.5
+      parent: 2
+  - uid: 6005
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,35.5
+      parent: 2
+  - uid: 6006
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,35.5
+      parent: 2
+- proto: CableApcExtension
+  entities:
+  - uid: 6012
+    components:
+    - type: Transform
+      pos: -2.5,42.5
+      parent: 2
+  - uid: 6013
+    components:
+    - type: Transform
+      pos: -1.5,42.5
+      parent: 2
+  - uid: 6014
+    components:
+    - type: Transform
+      pos: -0.5,42.5
+      parent: 2
+  - uid: 6015
+    components:
+    - type: Transform
+      pos: 0.5,42.5
+      parent: 2
+  - uid: 6016
+    components:
+    - type: Transform
+      pos: 1.5,42.5
+      parent: 2
+  - uid: 6017
+    components:
+    - type: Transform
+      pos: 2.5,42.5
+      parent: 2
+  - uid: 6018
+    components:
+    - type: Transform
+      pos: 3.5,42.5
+      parent: 2
+  - uid: 6019
+    components:
+    - type: Transform
+      pos: -2.5,41.5
+      parent: 2
+  - uid: 6020
+    components:
+    - type: Transform
+      pos: 0.5,41.5
+      parent: 2
+  - uid: 6021
+    components:
+    - type: Transform
+      pos: 3.5,41.5
+      parent: 2
+  - uid: 6022
+    components:
+    - type: Transform
+      pos: -2.5,40.5
+      parent: 2
+  - uid: 6023
+    components:
+    - type: Transform
+      pos: -1.5,40.5
+      parent: 2
+  - uid: 6024
+    components:
+    - type: Transform
+      pos: -0.5,40.5
+      parent: 2
+  - uid: 6025
+    components:
+    - type: Transform
+      pos: 0.5,40.5
+      parent: 2
+  - uid: 6026
+    components:
+    - type: Transform
+      pos: 1.5,40.5
+      parent: 2
+  - uid: 6027
+    components:
+    - type: Transform
+      pos: 2.5,40.5
+      parent: 2
+  - uid: 6028
+    components:
+    - type: Transform
+      pos: 3.5,40.5
+      parent: 2
+  - uid: 6029
+    components:
+    - type: Transform
+      pos: -2.5,39.5
+      parent: 2
+  - uid: 6030
+    components:
+    - type: Transform
+      pos: 3.5,39.5
+      parent: 2
+  - uid: 6031
+    components:
+    - type: Transform
+      pos: -2.5,38.5
+      parent: 2
+  - uid: 6032
+    components:
+    - type: Transform
+      pos: 3.5,38.5
+      parent: 2
+  - uid: 6033
+    components:
+    - type: Transform
+      pos: -2.5,37.5
+      parent: 2
+  - uid: 6034
+    components:
+    - type: Transform
+      pos: 3.5,37.5
+      parent: 2
+  - uid: 6035
+    components:
+    - type: Transform
+      pos: -2.5,36.5
+      parent: 2
+  - uid: 6036
+    components:
+    - type: Transform
+      pos: 3.5,36.5
+      parent: 2
+  - uid: 6038
+    components:
+    - type: Transform
+      pos: -2.5,35.5
+      parent: 2
+  - uid: 6039
+    components:
+    - type: Transform
+      pos: -1.5,35.5
+      parent: 2
+  - uid: 6040
+    components:
+    - type: Transform
+      pos: -0.5,35.5
+      parent: 2
+  - uid: 6041
+    components:
+    - type: Transform
+      pos: 0.5,35.5
+      parent: 2
+  - uid: 6042
+    components:
+    - type: Transform
+      pos: 1.5,35.5
+      parent: 2
+  - uid: 6043
+    components:
+    - type: Transform
+      pos: 2.5,35.5
+      parent: 2
+  - uid: 6044
+    components:
+    - type: Transform
+      pos: 3.5,35.5
       parent: 2
 - proto: DefaultStationBeaconCERoom
   entities:
@@ -9159,7 +9404,7 @@ entities:
       pos: 0.5,10.5
       parent: 2
     - type: NavMapBeacon
-      text: TEG
+      text: Factory Floor
 - proto: DefaultStationBeaconFrontierBreakRoom
   entities:
   - uid: 3513
@@ -9195,6 +9440,13 @@ entities:
 - proto: DogBed
   entities:
   - uid: 599
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+- proto: NFVendingMachineCart
+  entities:
+  - uid: 4353
     components:
     - type: Transform
       pos: 7.5,-0.5
@@ -10089,12 +10341,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -39.5,5.5
       parent: 2
+    - type: Docking
+      name: T-1
   - uid: 1499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,5.5
       parent: 2
+    - type: Docking
+      name: T-2
 - proto: GasMinerNitrogenStationLarge
   entities:
   - uid: 3559
@@ -16628,12 +16884,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -39.5,46.5
       parent: 2
+    - type: Docking
+      name: B-1
   - uid: 4339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,46.5
       parent: 2
+    - type: Docking
+      name: B-2
 - proto: GasSaleConsole
   entities:
   - uid: 4340
@@ -16684,12 +16944,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -39.5,-40.5
       parent: 2
+    - type: Docking
+      name: S-1
   - uid: 4342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-40.5
       parent: 2
+    - type: Docking
+      name: S-2
 - proto: GasValve
   entities:
   - uid: 294
@@ -24855,6 +25119,18 @@ entities:
     components:
     - type: Transform
       pos: -17.5,17.5
+      parent: 2
+- proto: VendingMachineFuelVend
+  entities:
+  - uid: 4351
+    components:
+    - type: Transform
+      pos: -12.5,0.5
+      parent: 2
+  - uid: 4352
+    components:
+    - type: Transform
+      pos: 13.5,0.5
       parent: 2
 - proto: VendingMachineYouToolPOI
   entities:

--- a/Resources/Maps/_6MD/POI/HestiaFactory.yml
+++ b/Resources/Maps/_6MD/POI/HestiaFactory.yml
@@ -24821,15 +24821,6 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 4162
-    components:
-    - type: Transform
-      pos: -6.5,3.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 5
-    - type: Battery
-      startingCharge: 0
   - uid: 4163
     components:
     - type: Transform
@@ -24933,6 +24924,13 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
+- proto: MachineCryoSleepPod
+  entities:
+  - uid: 6045
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
 - proto: SubstationBasicEmpty
   entities:
   - uid: 1808

--- a/Resources/Maps/_6MD/POI/HestiaFactory.yml
+++ b/Resources/Maps/_6MD/POI/HestiaFactory.yml
@@ -8677,15 +8677,17 @@ entities:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
-  - uid: 4133
-    components:
-    - type: Transform
-      pos: -16.5,9.5
-      parent: 2
   - uid: 4134
     components:
     - type: Transform
       pos: 17.5,7.5
+      parent: 2
+- proto: CrateMachine
+  entities:
+  - uid: 4133
+    components:
+    - type: Transform
+      pos: -16.5,9.5
       parent: 2
   - uid: 4135
     components:

--- a/Resources/Maps/_NF/POI/medical.yml
+++ b/Resources/Maps/_NF/POI/medical.yml
@@ -12320,13 +12320,13 @@ entities:
     - type: Transform
       pos: -4.5,31.5
       parent: 1
+- proto: DefaultStationBeaconATUWing
+  entities:
   - uid: 1531
     components:
     - type: Transform
       pos: 0.5,39.5
       parent: 1
-    - type: NavMapBeacon
-      text: ATU wing
 - proto: DefaultStationBeaconBar
   entities:
   - uid: 1532

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -303,6 +303,14 @@
 
 - type: entity
   parent: DefaultStationBeaconMedical
+  id: DefaultStationBeaconATUWing
+  suffix: ATU wing
+  components:
+  - type: NavMapBeacon
+    text: ATU wing
+
+- type: entity
+  parent: DefaultStationBeaconMedical
   id: DefaultStationBeaconSurgery
   suffix: Surgery
   components:

--- a/Resources/Prototypes/_6md/PointsOfInterest/HestiaFactory.yml
+++ b/Resources/Prototypes/_6md/PointsOfInterest/HestiaFactory.yml
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     HestiaFactory:
-      stationProto: RecordsFrontierOutpost
+      stationProto: RecordsFrontierOutpostCargo
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Hestia Factory'

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
@@ -457,12 +457,12 @@
     appearanceDataInit:
       enum.PdaVisuals.PdaType:
         !type:String
-        pda-planttechnician
+        pda-engineer
   - type: PdaBorderColor
     borderColor: "#949137"
     accentVColor: "#A32D26"
   - type: Icon
-    state: pda-planttechnician
+    state: pda-engineer
 
 - type: entity
   parent: BasePDA
@@ -476,11 +476,13 @@
     appearanceDataInit:
       enum.PdaVisuals.PdaType:
         !type:String
-        pda-plantmanager
+        pda-seniorengineer
   - type: PdaBorderColor
     borderColor: "#949137"
-    accentVColor: "#A32D26"
+    accentVColor: "#CD6900"
     accentHColor: "#447987"
+  - type: Icon
+    state: pda-seniorengineer
   - type: CartridgeLoader
     preinstalled:
     - CrewManifestCartridge


### PR DESCRIPTION
## About the PR
Bundles several Hestia Factory POI improvements and one navmap bug fix:

- **Navmap beacon fix**: `OnNavMapBeaconMapInit` previously returned early when `NavMapBeacon.Text` was already set, so explicitly-labelled beacons were never registered. The early return is removed so all beacons now update the navmap state correctly. Fallback name resolution is also tightened to treat whitespace-only strings as empty.
- **Hestia beacon labels**: Renamed all generic placeholder beacons on the Hestia Factory grid (transit docks, cargo bays, gas docks, factory floor, particle accelerator marker). Added a `DefaultStationBeaconATUWing` prototype and wired it into the Medical Dispatch map.
- **Hestia cargo consoles**: Changed the Hestia station prototype from `RecordsFrontierOutpost` (records-only) to `RecordsFrontierOutpostCargo` so the cargo request console properly populates.
- **North telepad → crate machine**: Replaced the two northern `CargoTelepad` entities with `CrateMachine` on both sides of the north dock.
- **Cryo sleep pod**: Added a `MachineCryoSleepPod` to the break room (below the west north-east station map); removed that station map.
- **PDA sprite restyle**: `PlantManagerPDA` now uses the senior-engineer sprite and border colours; `PlantTechnicianPDA` uses the standard engineer sprite.

Closes #79
Closes #78
Closes #75
Closes #65
Closes #64
Closes #63

## Why / Balance
- The navmap fix ensures any manually-labelled beacon (not just default-text ones) appears on the station map for crew navigation — this was a silent data loss bug.
- Cargo console fix restores expected NF outpost cargo gameplay on Hestia; without a cargo-capable station prototype the console shows nothing.
- Crate machines on the north dock allow the dock to function as an order-delivery point independent of the southern telepad pair.
- The cryo pod gives Hestia crew a respawn/late-join point inside the break room, matching standard NF outpost amenities.
- PDA sprites are visual-only reskins to better reflect the engineering theme of the Plant Manager and Plant Technician roles; no stat or access changes.

## Media
No media attached. Most changes are map layout or invisible system wiring. PDA sprite changes use existing engine sprites (`pda-seniorengineer`, `pda-engineer`) — no new art required.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Load the **Hestia Factory** POI map.
2. Open the station map — confirm all renamed beacons (Transit 1/2, Cargo Bay 1/2, Gas Dock 1/2, Factory Floor, Particle Accelerator, Break Room) appear correctly.
3. Open the **cargo request console** on Hestia — confirm the order list populates (was blank before).
4. Confirm north dock has two `CrateMachine` entities instead of telepads.
5. Confirm `MachineCryoSleepPod` is present in the break room and functional.
6. Load **Medical Dispatch** — confirm the ATU wing beacon appears on the station map.
7. Give a Plant Manager and Plant Technician their PDAs in-game and verify the correct sprite displays for each.

## Breaking changes
- `DefaultStationBeaconATUWing` is a new prototype added to `station_beacon.yml`. No renames; no migrations required.
- `PlantManagerPDA` and `PlantTechnicianPDA` sprite states changed (`pda-plantmanager` → `pda-seniorengineer`, `pda-planttechnician` → `pda-engineer`). Any downstream content that relied on those specific RSI states for customisation will need updating.

## Changelog
:cl:
- fix: Station map beacons with explicit text labels now correctly appear on the navmap.
- fix: Hestia Factory cargo request console now populates orders correctly.
- add: Added ATU Wing navmap beacon to the Medical Dispatch POI.
- add: Added cryo sleep pod to the Hestia Factory break room.
- tweak: Replaced north cargo telepads on Hestia Factory with crate machines.
- tweak: Plant Manager PDA now uses the senior engineer sprite; Plant Technician PDA uses the engineer sprite.