### PR TITLE
Fix Cutter Machine Material Silo Linking

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -857,6 +857,7 @@
       - RawMaterial
       - Plastic
       - Ingot # Frontier
+  - type: OreSiloClient
 
 # Shitmed Change Start
 - type: entity


### PR DESCRIPTION
## About the PR
Adds missing ore silo client support to the cutter machine so it can be linked to a material silo.

This updates the cutter machine prototype to include silo-client behavior, matching other silo-linkable fabrication machines. Previously, the cutter had material storage but could not connect to a silo.

Closes #81

## Why / Balance
This is a functionality fix, not a balance change.  
It restores expected station workflow by allowing cutter material usage to be centralized through a silo network.

## Media
Not required. This is a small machine-linking fix with no new visual content.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Spawn or construct a cutter machine and a material silo.
2. Link the cutter to the silo using normal in-game linking workflow.
3. Verify the cutter now reports as silo-linked and can consume silo-provided materials for recipes.
4. Confirm behavior is unchanged for non-silo usage (direct material insertion still works).

Validation performed for this commit:
- Confirmed latest commit only changes the cutter machine prototype entry.
- Did not run a full automated test suite in this PR preparation step.

## Breaking changes
None.

## Changelog
:cl:
- fix: Cutter machines can now be connected to material silos.