### PR TITLE
Fix Lathe Queue Persistence Serialization

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -316,6 +316,11 @@ public sealed partial class LatheMenu : FancyWindow
         return new Control();
     }
 
+    public Control GetRecipeDisplayControl(ProtoId<LatheRecipePrototype> recipe)
+    {
+        return GetRecipeDisplayControl(_prototypeManager.Index(recipe));
+    }
+
     private void OnItemSelected(OptionButton.ItemSelectedEventArgs obj)
     {
         FilterOption.SelectId(obj.Id);

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -241,7 +241,7 @@ namespace Content.Server.Lathe
                 return false;
 
             // Frontier: queue up a batch
-            if (component.Queue.Count > 0 && component.Queue[^1].Recipe.ID == recipe.ID)
+            if (component.Queue.Count > 0 && component.Queue[^1].Recipe == recipe.ID)
                 component.Queue[^1].ItemsRequested += quantity;
             else
                 component.Queue.Add(new LatheRecipeBatch(recipe, 0, quantity,
@@ -267,7 +267,7 @@ namespace Content.Server.Lathe
             // Frontier: handle batches
             var batch = component.Queue.First();
             var actor = batch.Actor; // Mono: Adds actor
-            var recipe = batch.Recipe;
+            var recipe = _proto.Index(batch.Recipe);
             // <Mono> - resources now consumed as the production goes
             if (!CanProduce(uid, recipe, 1, component))
             {
@@ -388,7 +388,9 @@ namespace Content.Server.Lathe
             if (!Resolve(uid, ref component))
                 return;
 
-            var producing = component.CurrentRecipe ?? component.Queue.FirstOrDefault()?.Recipe; // Frontier: add ?.Recipe
+            LatheRecipePrototype? producing = component.CurrentRecipe;
+            if (producing == null && component.Queue.FirstOrDefault() is { } queued)
+                producing = _proto.Index(queued.Recipe);
 
             var state = new LatheUpdateState(GetAvailableRecipes(uid, component), component.Queue, producing, component.Loop, component.SkipBad); // Mono
             _uiSys.SetUiState(uid, LatheUiKey.Key, state);

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -5,6 +5,7 @@ using Content.Shared.Research.Prototypes;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Lathe
 {
@@ -178,24 +179,39 @@ namespace Content.Shared.Lathe
     }
 
     // Frontier: batch lathe recipes
-    [Serializable]
+    [DataDefinition, Serializable, NetSerializable]
     public sealed partial class LatheRecipeBatch
     {
         private static int NextIndex = 0; // Mono
+        [DataField]
         public int Index; // Mono - for de-queuing recipes to work properly
-        public LatheRecipePrototype Recipe;
+        [DataField]
+        public ProtoId<LatheRecipePrototype> Recipe;
+        [DataField]
         public NetEntity? Actor; // Mono - Log the person who queued the recipe.
+        [DataField]
         public int ItemsPrinted;
+        [DataField]
         public int ItemsRequested;
 
         public LatheRecipeBatch(LatheRecipePrototype recipe, int itemsPrinted, int itemsRequested,
             NetEntity? actor) // Mono
         {
-            Recipe = recipe;
+            Recipe = recipe.ID;
             ItemsPrinted = itemsPrinted;
             ItemsRequested = itemsRequested;
             Actor = actor; // Mono
             Index = NextIndex++; // Mono
+        }
+
+        public LatheRecipeBatch(ProtoId<LatheRecipePrototype> recipe, int itemsPrinted, int itemsRequested,
+            NetEntity? actor)
+        {
+            Recipe = recipe;
+            ItemsPrinted = itemsPrinted;
+            ItemsRequested = itemsRequested;
+            Actor = actor;
+            Index = NextIndex++;
         }
     }
     // End Frontier

--- a/Content.Shared/Lathe/SharedLatheSystem.cs
+++ b/Content.Shared/Lathe/SharedLatheSystem.cs
@@ -75,7 +75,7 @@ public abstract class SharedLatheSystem : EntitySystem
         var currentMaterial = _materialStorage.GetStoredMaterials(ent.Owner);
         foreach (var batch in ent.Comp.Queue)
         {
-            var recipe = batch.Recipe;
+            var recipe = _proto.Index(batch.Recipe);
             foreach (var (material, needed) in recipe.Materials)
             {
                 var adjustedAmount = AdjustMaterial(needed, recipe.MaterialDiscountScale, ent.Comp.FinalMaterialUseMultiplier);


### PR DESCRIPTION
## About the PR
Fixes a persistence serialization failure for lathe queues on anchored persistent ships, especially when a looping lathe reaches the end of its loop.

`LatheRecipeBatch` is now a proper data definition and stores queued recipes as prototype IDs instead of prototype instances. Server/shared lathe code now resolves those IDs back to prototypes at use sites, and the lathe UI was updated to render queue entries from `ProtoId<LatheRecipePrototype>`.

This prevents snapshot save crashes caused by:
`System.InvalidOperationException: No data definition found for type Content.Shared.Lathe.LatheRecipeBatch when writing`.

## Why / Balance
This is a stability/reliability fix for persistence, not a balance change. It does not alter recipe costs, speeds, or output behavior.

## Media
Not required (internal serialization/persistence fix).

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Start a server with persistence anchors enabled.
2. On an anchored persistent ship/grid, set up an industrial lathe with loop enabled and a repeating queue.
3. Let it run until it reaches loop rollover (end of queued batch and re-queue behavior).
4. Trigger persistence save/snapshot for the anchored grid.
5. Confirm no serializer exception is logged for `Lathe`/`LatheRecipeBatch`, and the snapshot save succeeds.
6. Reload/restart and verify the lathe queue/production state still behaves correctly.

Automated tests were not added for this change.

## Breaking changes
None expected. No prototype renames or public API removals.

## Changelog
:cl:
- fix: Fixed persistent anchored ship snapshots failing to save when looping lathes reached the end of their queue.