### PR TITLE
Fix Uniform Printer Material Silo Linking (#84)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -672,6 +672,7 @@
       - Sheet
       - RawMaterial
       - Ingot
+  - type: OreSiloClient
 
 - type: entity
   id: Biogenerator


### PR DESCRIPTION
## About the PR
Fixes the uniform printer so it can be linked to a material silo like other lathe-style machines.

This adds the missing ore silo client component to the uniform printer prototype, enabling it to appear in silo client lists and consume silo-provided materials after linking.

Closes #84

## Why / Balance
The uniform printer already uses material storage and fits the same workflow as other production machines, but it was missing silo integration. This made it inconsistent with player expectations and forced local stocking only.

Balance impact is minimal: this is a parity/consistency fix for existing production behavior, not a new capability beyond intended silo support.

## Media
No media required. This is a small behavior fix with no new visuals.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Spawn/place a powered material silo and a powered uniform printer on the same grid and within silo range.
2. Open the material silo UI.
3. Verify the uniform printer appears in the client list and can be toggled on.
4. Insert printable recipes/material context as needed and print an item from the uniform printer.
5. Confirm materials are consumed from the silo-linked storage path (and linking state behaves like other silo-capable lathes).

## Breaking changes
None.

## Changelog
:cl:
- fix: Fixed uniform printers not being linkable to material silos.