### PR TITLE
Fix Reagent Dispenser Beaker Slot After Ship Restore (#83)

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -255,10 +255,14 @@ namespace Content.Server.Chemistry.EntitySystems
                 var ev = new RefreshPartsEvent { PartRatings = partRatings };
                 RaiseLocalEvent(uid, ev);
             }
+
+            EnsureOutputSlot(uid, component);
         }
 
         private void OnDispenserStartup(EntityUid uid, ReagentDispenserComponent component, ComponentStartup args)
         {
+            EnsureOutputSlot(uid, component);
+
             var slotCount = Math.Max(component.NumSlots, Math.Max(component.StorageSlots.Count, component.StorageSlotIds.Count));
             if (slotCount == 0)
             {
@@ -342,7 +346,7 @@ namespace Content.Server.Chemistry.EntitySystems
             }
             */ // End Frontier: no need to change slots, already done through RefreshParts
 
-            _itemSlotsSystem.AddItemSlot(uid, SharedReagentDispenser.OutputSlotName, component.BeakerSlot);
+            EnsureOutputSlot(uid, component);
 
             // Restore path can deserialize container contents but leave slot registration/state out of sync.
             // Rebuild slot registration from the serialized slot/container data.
@@ -469,6 +473,20 @@ namespace Content.Server.Chemistry.EntitySystems
         private void OnUpgradeExamine(EntityUid uid, ReagentDispenserComponent component, UpgradeExamineEvent args)
         {
             args.AddNumberUpgrade("reagent-dispenser-component-examine-extra-slots", component.NumSlots - component.BaseNumStorageSlots);
+        }
+
+        private void EnsureOutputSlot(EntityUid uid, ReagentDispenserComponent component)
+        {
+            if (_itemSlotsSystem.TryGetSlot(uid, SharedReagentDispenser.OutputSlotName, out var existingSlot))
+            {
+                if (existingSlot.ContainerSlot == null)
+                    _itemSlotsSystem.RebindItemSlot(uid, SharedReagentDispenser.OutputSlotName, existingSlot);
+
+                component.BeakerSlot = existingSlot;
+                return;
+            }
+
+            _itemSlotsSystem.AddItemSlot(uid, SharedReagentDispenser.OutputSlotName, component.BeakerSlot);
         }
         // End Frontier
     }


### PR DESCRIPTION
## About the PR
Fixes reagent dispensers so their beaker/output slot is rebuilt correctly after a ship is stored and later restored.

The change centralizes output-slot recovery in the reagent dispenser system and runs it on init, startup, and map init. This keeps the dispenser's beaker slot registered even when ship snapshot restore paths leave item slot state partially deserialized.

Closes #83

## Why / Balance
This fixes a regression in ship persistence where onboard chemical dispensers could no longer accept beakers after storage. There is no intended balance change; this restores expected machine functionality for chemistry equipment on stored ships.

## Media
Not required. This is a small bug fix with no new visual content.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Spawn or acquire a ship with a chemical dispenser.
Store the ship, then restore it.
Try inserting a beaker into the dispenser.
Confirm the beaker slot is still present and the dispenser accepts and uses the beaker normally.

No automated test was added for this change.

## Breaking changes
None.

## Changelog
:cl:
- fix: Fixed ship chemical dispensers losing their beaker slot after the ship is stored and restored.