### PR TITLE
Fix Magnet Pickup Timers After Ship Restore (#85)

### DIFF
--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Storage.Components; // Frontier: Server<Shared
 [NetworkedComponent, AutoGenerateComponentState] // Frontier
 public sealed partial class MagnetPickupComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
+    [ViewVariables(VVAccess.ReadWrite)]
     [AutoPausedField]
     public TimeSpan NextScan = TimeSpan.Zero;
 

--- a/Content.Shared/Storage/Components/MaterialReclaimerMagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MaterialReclaimerMagnetPickupComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Server.Storage.Components;
 [RegisterComponent]
 public sealed partial class MaterialReclaimerMagnetPickupComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
+    [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan NextScan = TimeSpan.Zero;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]

--- a/Content.Shared/Storage/Components/MaterialStorageMagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MaterialStorageMagnetPickupComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Server.Storage.Components;
 [RegisterComponent]
 public sealed partial class MaterialStorageMagnetPickupComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
+    [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan NextScan = TimeSpan.Zero;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]


### PR DESCRIPTION
## About the PR
Fixes a persistence-related magnet pickup regression on restored ships by making magnet scan timers runtime-only instead of serialized state.

After a ship is loaded from shipyard or persistence anchor snapshots, ore and material magnets could play pickup animation client-side but fail to actually collect items server-side. Replacing the box worked because a newly spawned entity starts with a fresh runtime timer. This PR removes serialization of the magnet scan timer field so restored entities always resume normal scanning behavior.

Closes #85

## Why / Balance
This restores expected mining and material-handling behavior on persistent ships and removes a frustrating desync-like failure mode. No intentional balance changes are introduced; this is a functional reliability fix for existing mechanics.

## Media
Not required. This is a logic/persistence fix without new visual content.

## Requirements
- [ ] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Start with a ship that has ore/material magnet containers and verify they pick up normally.
2. Store and restore the ship through shipyard or persistence anchor flow.
3. Place ore/material entities in magnet range.
4. Confirm items are actually inserted into the container after restore (not just animated).
5. Confirm newly spawned and pre-existing magnet containers both behave the same.

Validation performed for this PR:
- Built Content.Server successfully.

## Breaking changes
None.

## Changelog
:cl:
- fix: Fixed ore/material magnet containers on restored persistent ships failing to collect items due to stale serialized scan timers.